### PR TITLE
Fixed type erasing in StateConnectionViewGuard.

### DIFF
--- a/Sources/SwiftDux/UI/ViewModifiers/StateConnectionViewModifier.swift
+++ b/Sources/SwiftDux/UI/ViewModifiers/StateConnectionViewModifier.swift
@@ -54,10 +54,7 @@ private struct StateConnectionViewGuard<State, Content> : View where Content : V
   var content: Content
   
   var body: some View {
-    if stateConnection.latestState != nil {
-      return AnyView(content)
-    }
-    return AnyView(EmptyView())
+    stateConnection.latestState.map { _ in content }    
   }
   
 }


### PR DESCRIPTION
# Fixed
- Fixed type erasing in StateConnectionViewGuard by returning the contents as an optional view rather than using AnyView.