### PR TITLE
Cancellable Action Plans

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           sudo xcode-select -s /Applications/Xcode_11.app
           brew install mint
-          mint install apple/swift-format
+          mint install apple/swift-format@swift-5.1-branch
       - name: Check code formatting
         run: |
           swift-format -r -m lint Sources

--- a/Sources/SwiftDux/Action/ActionPlan.swift
+++ b/Sources/SwiftDux/Action/ActionPlan.swift
@@ -65,4 +65,57 @@ public struct ActionPlan<State>: Action where State: StateType {
   public func run(_ store: StoreProxy<State>) -> AnyPublisher<Action, Never>? {
     self.body(store)
   }
+
+  /// Send an action plan that can be cancelled.
+  ///
+  /// This is useful for action plans that return a publisher that require a cancellable step. For example, a web request
+  /// that should be cancelled if the user navigates away from the relevant view.
+  ///
+  /// ```
+  /// struct MyView: View {
+  ///
+  ///   @MappedDispatch() private var dispatch
+  ///
+  ///   @State private var username: String = ""
+  ///   @State private var password: String = ""
+  ///
+  ///   @State private var signUpCancellable: AnyCancellable? = nil
+  ///
+  ///   var body: some View {
+  ///     Group {
+  ///       /// ...signup form
+  ///       Button(action: self.signUp) { Text("Sign Up") }
+  ///     }
+  ///     .onDisappear { self.signUpCancellable?.cancel() }
+  ///   }
+  ///
+  ///   func signUp() {
+  ///     signUpCancellable = signUpActionPlan(username: username, password: password).sendAsCancellable(dispatch)
+  ///   }
+  ///
+  /// }
+  /// ```
+  ///
+  /// - Parameter send: The send function that dispatches an action.
+  /// - Returns: AnyCancellable to cancel the action plan.
+  public func sendAsCancellable(_ send: SendAction) -> AnyCancellable {
+    var cancelled: Bool = false
+    var publisherCancellable: AnyCancellable? = nil
+
+    send(
+      ActionPlan<State> { store -> () in
+        guard cancelled == false else { return }
+        guard let publisher = self.run(store) else { return }
+        publisherCancellable
+          = publisher.sink { action in
+            store.send(action)
+          }
+      }
+    )
+
+    return AnyCancellable {
+      cancelled = true
+      publisherCancellable?.cancel()
+    }
+  }
 }

--- a/Tests/SwiftDuxTests/Action/ActionPlanTests.swift
+++ b/Tests/SwiftDuxTests/Action/ActionPlanTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+import Combine
+import Dispatch
+@testable import SwiftDux
+
+final class ActionPlanTests: XCTestCase {
+  var store: Store<TestState>!
+  var sendAction: SendAction!
+  var storeProxy: StoreProxy<TestState>!
+  var sentActions: [TestAction] = []
+  
+  override func setUp() {
+    store = Store(state: TestState(), reducer: TestReducer())
+    sendAction = { [weak self] action in
+      if let action = action as? TestAction {
+        self?.sentActions.append(action)
+      }
+      if let action = action as? ActionPlan<TestState>, let storeProxy = self?.storeProxy {
+        _ = action.run(storeProxy)
+      }
+    }
+    storeProxy = StoreProxy(store: store, send: sendAction)
+    sentActions = []
+  }
+  
+  func assertActionsWereSent(_ expected: [TestAction]) {
+    XCTAssertEqual(sentActions, expected)
+  }
+  
+  func testEmptyActionPlan() {
+    let actionPlan = ActionPlan<TestState> { _ in }
+    _ = actionPlan.run(storeProxy)
+    assertActionsWereSent([])
+  }
+  
+  func testBasicActionPlan() {
+    let actionPlan = ActionPlan<TestState> { $0.send(TestAction.actionA) }
+    _ = actionPlan.run(storeProxy)
+    assertActionsWereSent([TestAction.actionA])
+  }
+  
+  func testActionPlanWithMultipleSends() {
+    let actionPlan = ActionPlan<TestState> {
+      $0.send(TestAction.actionA)
+      $0.send(TestAction.actionB)
+      $0.send(TestAction.actionA)
+    }
+    _ = actionPlan.run(storeProxy)
+    assertActionsWereSent([
+      TestAction.actionA,
+      TestAction.actionB,
+      TestAction.actionA
+    ])
+  }
+  
+  func testPublishableActionPlan() {
+    let actionPlan = ActionPlan<TestState> { _ in
+      Publishers.Sequence<[Action], Never>(sequence: [TestAction.actionB, TestAction.actionA])
+    }
+    if let publisher = actionPlan.run(storeProxy) {
+      _ = publisher.sink(receiveValue: sendAction)
+    }
+    assertActionsWereSent([
+      TestAction.actionB,
+      TestAction.actionA
+    ])
+  }
+  
+  func testCancellableActionPlan() {
+    let expectation = XCTestExpectation(description: "Expect one cancellation")
+    expectation.expectedFulfillmentCount = 2
+    
+    let actionPlan = ActionPlan<TestState> { _ in
+      Future<Action, Never> { promise in
+        DispatchQueue.main.asyncAfter(deadline: .init(uptimeNanoseconds: 10000)) {
+          promise(.success(TestAction.actionB))
+        }
+      }
+      .handleEvents(
+        receiveCompletion: { _ in expectation.fulfill() },
+        receiveCancel: { expectation.fulfill() }
+      )
+    }
+    
+    let cancellables = [
+      actionPlan.sendAsCancellable(sendAction),
+      actionPlan.sendAsCancellable(sendAction)
+    ]
+    cancellables[1].cancel()
+    
+    wait(for: [expectation], timeout: 1.0)
+    
+    assertActionsWereSent([
+      TestAction.actionB
+    ])
+  }
+
+  static var allTests = [
+    ("testBasicActionPlan", testBasicActionPlan)
+  ]
+}
+
+extension ActionPlanTests {
+  
+  enum TestAction: Action, Equatable {
+    case actionA
+    case actionB
+  }
+  
+  struct TestState: StateType {}
+  
+  class TestReducer: Reducer {
+    func reduce(state: TestState, action: TestAction) -> TestState {
+      state
+    }
+  }
+  
+}


### PR DESCRIPTION
- Added method to ActionPlan<_> to send it with a returned cancellable object. This is only useful by plans that return a publisher.

