### PR TITLE
Manually Encode and Decode OrderedState<_>

### DIFF
--- a/Sources/SwiftDux/State/OrderedState.swift
+++ b/Sources/SwiftDux/State/OrderedState.swift
@@ -97,12 +97,12 @@ public struct OrderedState<Substate>: StateType where Substate: IdentifiableStat
 
   /// The substates as an ordered array
   public var values: [Substate] {
-    return storage.orderOfIds.map { storage.values[$0]! }
+    storage.orderOfIds.map { storage.values[$0]! }
   }
 
   /// The number of substates
   public var count: Int {
-    return storage.orderOfIds.count
+    storage.orderOfIds.count
   }
 
   /// Used for internal copy operations.
@@ -176,6 +176,16 @@ public struct OrderedState<Substate>: StateType where Substate: IdentifiableStat
     }
     storage.invalidateCache()
     return storage
+  }
+
+  /// Retrieves a value by its id.
+  ///
+  /// The subscript API should be used in most cases. This method is
+  /// provided in case the Substate's id type is also an int.
+  /// - Parameter id: The id of the substate.
+  /// - Returns: The substate if it exists.
+  public func value(forId id: Id) -> Substate? {
+    return storage.values[id]
   }
 
   /// Append a new substate to the end of the `OrderedState`.
@@ -314,12 +324,12 @@ extension OrderedState: MutableCollection {
 
   /// The starting index of the collection.
   public var startIndex: Int {
-    return storage.orderOfIds.startIndex
+    storage.orderOfIds.startIndex
   }
 
   /// The last index of the collection.
   public var endIndex: Int {
-    return storage.orderOfIds.endIndex
+    storage.orderOfIds.endIndex
   }
 
   /// Subscript based on the index of the substate.
@@ -328,7 +338,7 @@ extension OrderedState: MutableCollection {
   /// - Returns: The substate
   public subscript(position: Int) -> Substate {
     get {
-      return storage.values[storage.orderOfIds[position]]!
+      storage.values[storage.orderOfIds[position]]!
     }
     set(newValue) {
       self.insert(newValue, at: position)
@@ -341,7 +351,7 @@ extension OrderedState: MutableCollection {
   /// - Returns: The substate
   public subscript(position: Id) -> Substate? {
     get {
-      return storage.values[position]
+      value(forId: position)
     }
     set(newValue) {
       guard let newValue = newValue else { return }
@@ -410,7 +420,7 @@ extension RangeReplaceableCollection where Self: MutableCollection, Index == Int
 extension OrderedState: Equatable {
 
   public static func == (lhs: OrderedState<Substate>, rhs: OrderedState<Substate>) -> Bool {
-    return lhs.storage === rhs.storage
+    return lhs.storage == rhs.storage
   }
 
 }

--- a/Sources/SwiftDux/State/OrderedState.swift
+++ b/Sources/SwiftDux/State/OrderedState.swift
@@ -106,6 +106,7 @@ public struct OrderedState<Substate>: StateType where Substate: IdentifiableStat
   }
 
   /// Used for internal copy operations.
+  ///
   /// - Parameters
   ///   - orderOfIds: The ids of each substate in a specific order.
   ///   - values: A lookup table of substates by their ids.
@@ -118,6 +119,7 @@ public struct OrderedState<Substate>: StateType where Substate: IdentifiableStat
   }
 
   /// Create a new `OrderedState` with an ordered array of identifiable substates.
+  /// 
   /// - Parameter values: An array of substates. The position of each substate will be used as the initial order.
   public init(_ values: [Substate]) {
     var valueByIndex = [Id: Substate](minimumCapacity: values.count)
@@ -133,7 +135,7 @@ public struct OrderedState<Substate>: StateType where Substate: IdentifiableStat
   public init(_ value: Substate...) {
     self.init(value)
   }
-  
+
   ///Decodes the `OrderState<_>` from an unkeyed container.
   ///
   /// This allows the `OrderedState<_>` to be decoded from a simple array.
@@ -151,7 +153,7 @@ public struct OrderedState<Substate>: StateType where Substate: IdentifiableStat
     }
     self.init(values)
   }
-  
+
   /// Encodes the `OrderState<_>` as an unkeyed container of values.
   ///
   /// This allows the `OrderedState<_>` to be encoded as simple array.
@@ -271,7 +273,7 @@ public struct OrderedState<Substate>: StateType where Substate: IdentifiableStat
     let copy = copyStorageIfNeeded()
     let index = Swift.max(Swift.min(index, copy.orderOfIds.count), 0)
     let ids = Array(indexSet.map { copy.orderOfIds[$0] })
-    let offset = indexSet.reduce(0) { (result, i) in i < index ? result + 1 : result }
+    let offset = Swift.max(indexSet.reduce(0) { (result, i) in i < index ? result + 1 : result } - 1, 0)
     copy.orderOfIds.remove(at: indexSet)
     copy.orderOfIds.insert(contentsOf: ids, at: index - offset)
     self.storage = copy

--- a/Tests/SwiftDuxTests/PerformanceTests.swift
+++ b/Tests/SwiftDuxTests/PerformanceTests.swift
@@ -14,7 +14,7 @@ final class PerformanceTests: XCTestCase {
       
       let firstMoveItem = store.state.todoLists["123"]?.todos.values[300]
       store.send(TodoListAction.moveTodos(inList: "123", from: IndexSet(300...5000), to: 8000))
-      XCTAssertEqual(firstMoveItem?.id, store.state.todoLists["123"]?.todos.values[3299].id)
+      XCTAssertEqual(firstMoveItem?.id, store.state.todoLists["123"]?.todos.values[3300].id)
       
       let firstUndeletedItem = store.state.todoLists["123"]?.todos.values[3001]
       store.send(TodoListAction.removeTodos(fromList: "123", at: IndexSet(100...3000)))

--- a/Tests/SwiftDuxTests/State/OrderedStateTests.swift
+++ b/Tests/SwiftDuxTests/State/OrderedStateTests.swift
@@ -126,6 +126,31 @@ final class OrderedStateTests: XCTestCase {
     let results = OrderedState(john, bob, bill).filter { $0.name == "Bob" }
     XCTAssertEqual(results, [bob])
   }
+  
+  func testIndexSubscript() {
+    let state = OrderedState(john, bob, bill).sorted { $0.name < $1.name }
+    XCTAssertEqual(state[2], john)
+  }
+  
+  func testIdSubscript() {
+    let state = OrderedState(john, bob, bill).sorted { $0.name < $1.name }
+    XCTAssertEqual(state["2"], bob)
+  }
+  
+  func testIdSubscriptWithInteger() {
+    let state = OrderedState(
+      Fruit(id: 1, name: "apple"),
+      Fruit(id: 2, name: "orange"),
+      Fruit(id: 3, name: "banana")
+    )
+    XCTAssertEqual(state[2], Fruit(id: 3, name: "banana"))
+    XCTAssertEqual(state.value(forId: 2), Fruit(id: 2, name: "orange"))
+  }
+  
+  func testEquality() {
+    XCTAssertNotEqual(OrderedState(bob, john, bill), OrderedState(john, bob, bill))
+    XCTAssertEqual(OrderedState(john, bob, bill), OrderedState(john, bob, bill))
+  }
 
   static var allTests = [
     ("testInitializeWithArray", testInitializeWithArray),
@@ -143,13 +168,25 @@ final class OrderedStateTests: XCTestCase {
     ("testMoveTwoUsersFoward", testMoveTwoUsersFoward),
     ("testMoveTwoUsersBackwards", testMoveTwoUsersBackwards),
     ("testMoveAllUsers", testMoveAllUsers),
+    ("testSort", testSort),
+    ("testSorted", testSorted),
+    ("testFilter", testFilter),
+    ("testIndexSubscript", testIndexSubscript),
+    ("testIdSubscript", testIdSubscript),
+    ("testIdSubscriptWithInteger", testIdSubscriptWithInteger),
+    ("testEquality", testEquality),
   ]
 }
 
 extension OrderedStateTests {
   
-  struct User: IdentifiableState {
+  struct User: IdentifiableState, Equatable {
     var id: String
+    var name: String
+  }
+  
+  struct Fruit: IdentifiableState {
+    var id: Double
     var name: String
   }
   

--- a/Tests/SwiftDuxTests/State/OrderedStateTests.swift
+++ b/Tests/SwiftDuxTests/State/OrderedStateTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+import Combine
+import Dispatch
+@testable import SwiftDux
+
+final class OrderedStateTests: XCTestCase {
+  let bob = User(id: "2", name: "Bob")
+  let bill = User(id: "3", name: "Bill")
+  let john = User(id: "1", name: "John")
+  
+  override func setUp() {
+  }
+  
+  func testInitializeWithArray() {
+    let state = OrderedState([bob, bill, john])
+    XCTAssertEqual(state.values, [bob, bill, john])
+  }
+  
+  func testInitializeWithVariadicArguments() {
+    let state = OrderedState(bob, bill, john)
+    XCTAssertEqual(state.values, [bob, bill, john])
+  }
+  
+  func testInitializeFromDecoder() {
+    let json = #"[{ "id": "1", "name": "John" }, { "id": "2", "name": "Bob" }, { "id": "3", "name": "Bill" }]"#
+    let data = json.data(using: .utf8)!
+    let decoder = JSONDecoder()
+    let state = try! decoder.decode(OrderedState<User>.self, from: data);
+    XCTAssertEqual(state.values, [john, bob, bill])
+  }
+  
+  func testEncode() {
+    let encoder = JSONEncoder()
+    let state = OrderedState(john, bob, bill)
+    let json = try! encoder.encode(state)
+    XCTAssertEqual(
+      String(decoding: json, as: UTF8.self),
+      #"[{"id":"1","name":"John"},{"id":"2","name":"Bob"},{"id":"3","name":"Bill"}]"#
+    )
+  }
+  
+  func testAppendNewItem() {
+    var state = OrderedState(bob, bill)
+    state.append(john)
+    XCTAssertEqual(state.values, [bob, bill, john])
+  }
+  
+  func testAppendExistingItem() {
+    var state = OrderedState(bob, john, bill)
+    state.append(john)
+    XCTAssertEqual(state.values, [bob, bill, john])
+  }
+  
+  func testPrepend() {
+    var state = OrderedState(bob, bill)
+    state.prepend(john)
+    XCTAssertEqual(state.values, [john, bob, bill])
+  }
+  
+  func testInsertNewItem() {
+    var state = OrderedState(bob, bill)
+    state.insert(john, at: 1)
+    XCTAssertEqual(state.values, [bob, john, bill])
+  }
+  
+  func testInsertExistingItem() {
+    var state = OrderedState(bob, bill, john)
+    state.insert(john, at: 1)
+    XCTAssertEqual(state.values, [bob, john, bill])
+  }
+  
+  func testRemove() {
+    var state = OrderedState(bob, bill, john)
+    state.remove(at: 1)
+    XCTAssertEqual(state.values, [bob, john])
+  }
+  
+  func testRemoveIndexSet() {
+    var state = OrderedState(bob, bill, john)
+    state.remove(at: IndexSet([0,2]))
+    XCTAssertEqual(state.values, [bill])
+  }
+  
+  func testMoveOneUserFoward() {
+    var state = OrderedState(bob, bill, john)
+    state.move(from: IndexSet([1]), to: 2)
+    XCTAssertEqual(state.values, [bob, john, bill])
+  }
+  
+  func testMoveOneUserBackwards() {
+    var state = OrderedState(bob, bill, john)
+    state.move(from: IndexSet([2]), to: 0)
+    XCTAssertEqual(state.values, [john, bob, bill])
+  }
+  
+  func testMoveTwoUsersFoward() {
+    var state = OrderedState(bob, bill, john)
+    state.move(from: IndexSet([0,1]), to: 2)
+    XCTAssertEqual(state.values, [john, bob, bill])
+  }
+  
+  func testMoveTwoUsersBackwards() {
+    var state = OrderedState(bob, bill, john)
+    state.move(from: IndexSet([1,2]), to: 0)
+    XCTAssertEqual(state.values, [bill, john, bob])
+  }
+  
+  func testMoveAllUsers() {
+    var state = OrderedState(bob, bill, john)
+    state.move(from: IndexSet([0,1, 2]), to: 2)
+    XCTAssertEqual(state.values, [bob, bill, john])
+  }
+  
+  func testSort() {
+    var state = OrderedState(john, bob, bill)
+    state.sort { $0.name < $1.name }
+    XCTAssertEqual(state.values, [bill, bob, john])
+  }
+  
+  func testSorted() {
+    let state = OrderedState(john, bob, bill).sorted { $0.name < $1.name }
+    XCTAssertEqual(state.values, [bill, bob, john])
+  }
+  
+  func testFilter() {
+    let results = OrderedState(john, bob, bill).filter { $0.name == "Bob" }
+    XCTAssertEqual(results, [bob])
+  }
+
+  static var allTests = [
+    ("testInitializeWithArray", testInitializeWithArray),
+    ("testInitializeWithVariadicArguments", testInitializeWithVariadicArguments),
+    ("testEncode", testEncode),
+    ("testAppendNewItem", testAppendNewItem),
+    ("testAppendExistingItem", testAppendExistingItem),
+    ("testPrepend", testPrepend),
+    ("testInsertNewItem", testInsertNewItem),
+    ("testInsertExistingItem", testInsertExistingItem),
+    ("testRemove", testRemove),
+    ("testRemoveIndexSet", testRemoveIndexSet),
+    ("testMoveOneUserFoward", testMoveOneUserFoward),
+    ("testMoveOneUserBackwards", testMoveOneUserBackwards),
+    ("testMoveTwoUsersFoward", testMoveTwoUsersFoward),
+    ("testMoveTwoUsersBackwards", testMoveTwoUsersBackwards),
+    ("testMoveAllUsers", testMoveAllUsers),
+  ]
+}
+
+extension OrderedStateTests {
+  
+  struct User: IdentifiableState {
+    var id: String
+    var name: String
+  }
+  
+}

--- a/Tests/SwiftDuxTests/XCTestManifests.swift
+++ b/Tests/SwiftDuxTests/XCTestManifests.swift
@@ -4,6 +4,8 @@ import XCTest
 public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(StoreTests.allTests),
+        testCase(ActionPlanTests.allTests),
+        testCase(OrderedStateTests.allTests),
     ]
 }
 #endif

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - Sources/SwiftDux/UI
+  - Tests


### PR DESCRIPTION
Apple's synthesized methods for Codable broke in a beta of iOS 13.2. This led to implementing it manually which provides a simpler output. Instead of encoding the struct as is, it encodes it as a simple array.

