### PR TITLE
Dispatch an Action When a View Appears

### DIFF
--- a/Sources/SwiftDux/Action/ActionPlan.swift
+++ b/Sources/SwiftDux/Action/ActionPlan.swift
@@ -30,7 +30,7 @@ import Foundation
 ///     dispatch(UserAction.loadUser(byId: self.id))
 ///   }
 ///```.
-public struct ActionPlan<State>: Action where State: StateType {
+public struct ActionPlan<State>: CancellableAction where State: StateType {
 
   /// The body of a publishable action plan.
   ///
@@ -98,9 +98,9 @@ public struct ActionPlan<State>: Action where State: StateType {
   ///
   /// - Parameter send: The send function that dispatches an action.
   /// - Returns: AnyCancellable to cancel the action plan.
-  public func sendAsCancellable(_ send: SendAction) -> AnyCancellable {
+  public func sendAsCancellable(_ send: SendAction) -> Cancellable {
     var cancelled: Bool = false
-    var publisherCancellable: AnyCancellable? = nil
+    var publisherCancellable: Cancellable? = nil
 
     send(
       ActionPlan<State> { store -> () in

--- a/Sources/SwiftDux/Action/CancellableAction.swift
+++ b/Sources/SwiftDux/Action/CancellableAction.swift
@@ -1,0 +1,43 @@
+import Combine
+import Foundation
+
+/// An action that can return a cancellable object. Don't use this protocol directly.
+/// Instead, use an ActionPlan. This allows action plans with a publisher to be explicitly cancelled by
+/// their source dispatcher rather than internally or by the store.
+public protocol CancellableAction: Action {
+
+  /// Send an action that returns a cancellabe object.
+  ///
+  /// This is useful for action plans that return a publisher that require a cancellable step. For example, a web request
+  /// that should be cancelled if the user navigates away from the relevant view.
+  ///
+  /// ```
+  /// struct MyView: View {
+  ///
+  ///   @MappedDispatch() private var dispatch
+  ///
+  ///   @State private var username: String = ""
+  ///   @State private var password: String = ""
+  ///
+  ///   @State private var signUpCancellable: AnyCancellable? = nil
+  ///
+  ///   var body: some View {
+  ///     Group {
+  ///       /// ...signup form
+  ///       Button(action: self.signUp) { Text("Sign Up") }
+  ///     }
+  ///     .onDisappear { self.signUpCancellable?.cancel() }
+  ///   }
+  ///
+  ///   func signUp() {
+  ///     signUpCancellable = signUpActionPlan(username: username, password: password).sendAsCancellable(dispatch)
+  ///   }
+  ///
+  /// }
+  /// ```
+  ///
+  /// - Parameter send: The send function that dispatches an action.
+  /// - Returns: AnyCancellable to cancel the action plan.
+  func sendAsCancellable(_ send: SendAction) -> Cancellable
+
+}

--- a/Sources/SwiftDux/Store/Store.swift
+++ b/Sources/SwiftDux/Store/Store.swift
@@ -67,6 +67,7 @@ extension Store: ActionDispatcher, Subscriber {
     if let publisher = actionPlan.run(StoreProxy(store: self)) {
       publisher.subscribe(self)
     }
+    didChange.send(actionPlan)
   }
 
   private func send(modifiedAction: ModifiedAction) {

--- a/Sources/SwiftDux/Store/StoreActionDispatcher.swift
+++ b/Sources/SwiftDux/Store/StoreActionDispatcher.swift
@@ -70,6 +70,8 @@ internal struct StoreActionDispatcher<State>: ActionDispatcher, Subscriber where
     if let publisher = actionPlan.run(StoreProxy(store: upstream, send: self.send)) {
       publisher.subscribe(self)
     }
+    upstream.didChange.send(actionPlan)
+    sentAction?(actionPlan)
   }
 
 }

--- a/Sources/SwiftDux/UI/StateConnection.swift
+++ b/Sources/SwiftDux/UI/StateConnection.swift
@@ -11,7 +11,7 @@ internal final class StateConnection<State>: ObservableObject, Identifiable {
 
   var getState: () -> State?
 
-  private var cancellable: AnyCancellable? = nil
+  private var cancellable: Cancellable? = nil
 
   init(getState: @escaping () -> State?, changePublisher: AnyPublisher<Void, Never>) {
     self.getState = getState

--- a/Sources/SwiftDux/UI/ViewModifiers/OnAppearDispatchViewModifier.swift
+++ b/Sources/SwiftDux/UI/ViewModifiers/OnAppearDispatchViewModifier.swift
@@ -15,8 +15,7 @@ internal struct OnAppearDispatchViewModifier: ViewModifier {
   }
 
   public func body(content: Content) -> some View {
-    return
-      content
+    content
       .onAppear { [action, dispatch] in
         guard self.cancellable == nil else { return }
         if let actionPlan = action as? CancellableAction {
@@ -27,6 +26,7 @@ internal struct OnAppearDispatchViewModifier: ViewModifier {
       }
       .onDisappear { [cancelOnDisappear] in
         if cancelOnDisappear {
+          self.cancellable?.cancel()
           self.cancellable = nil
         }
       }
@@ -36,9 +36,20 @@ internal struct OnAppearDispatchViewModifier: ViewModifier {
 
 extension View {
 
-  /// Sends the provided action when a view first appears. If an action plan is provided, it will send it as a cancellable plan.
+  /// Sends the provided action when the view appears. If an action plan is provided, it will send it as a cancellable plan.
   /// This let's the view modifier automatically clean up the publisher if it's connected to an external service or API when the view
-  /// is removed from the UI.
+  /// disappears.
+  ///
+  /// ```
+  /// @MappedState var items: [TodoItem]
+  ///
+  /// var body: some View {
+  ///   Group {
+  ///     TodoList(items: items)
+  ///   }
+  ///   .onAppear(dispatch: ActionPlans.queryTodoItems)
+  /// }
+  /// ```
   ///
   /// - Parameters:
   ///   - action: An action to dispatch every time the view appears.

--- a/Sources/SwiftDux/UI/ViewModifiers/OnAppearDispatchViewModifier.swift
+++ b/Sources/SwiftDux/UI/ViewModifiers/OnAppearDispatchViewModifier.swift
@@ -1,0 +1,53 @@
+import Combine
+import SwiftUI
+
+internal struct OnAppearDispatchViewModifier: ViewModifier {
+  @MappedDispatch() private var dispatch
+
+  var action: Action
+  var cancelOnDisappear: Bool
+
+  @State private var cancellable: Cancellable? = nil
+
+  internal init(action: Action, cancelOnDisappear: Bool) {
+    self.action = action
+    self.cancelOnDisappear = cancelOnDisappear
+  }
+
+  public func body(content: Content) -> some View {
+    return
+      content
+      .onAppear { [action, dispatch] in
+        guard self.cancellable == nil else { return }
+        if let actionPlan = action as? CancellableAction {
+          self.cancellable = actionPlan.sendAsCancellable(dispatch)
+        } else {
+          dispatch(action)
+        }
+      }
+      .onDisappear { [cancelOnDisappear] in
+        if cancelOnDisappear {
+          self.cancellable = nil
+        }
+      }
+  }
+
+}
+
+extension View {
+
+  /// Sends the provided action when a view first appears. If an action plan is provided, it will send it as a cancellable plan.
+  /// This let's the view modifier automatically clean up the publisher if it's connected to an external service or API when the view
+  /// is removed from the UI.
+  ///
+  /// - Parameters:
+  ///   - action: An action to dispatch every time the view appears.
+  ///   - cancelOnDisappear: It will cancel any subscription from the action when the view disappears. If false, it keeps
+  ///     the subscription alive and reppearances of the view will not re-call the action.
+  /// - Returns: The modified view.
+  @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+  public func onAppear(dispatch action: Action, cancelOnDisappear: Bool = true) -> some View {
+    modifier(OnAppearDispatchViewModifier(action: action, cancelOnDisappear: cancelOnDisappear))
+  }
+
+}

--- a/Tests/SwiftDuxTests/PerformanceTests.swift
+++ b/Tests/SwiftDuxTests/PerformanceTests.swift
@@ -27,7 +27,7 @@ final class PerformanceTests: XCTestCase {
     let subsriberCount = 100
     let sendCount = 10000
     var updateCounts = 0
-    var sinks = [AnyCancellable]()
+    var sinks = [Cancellable]()
     let store = Store(state: TestState.defaultState, reducer: TestReducer())
     
     sinks.reserveCapacity(subsriberCount)


### PR DESCRIPTION
# Summary
This PR allows a view to dispatch an action plan that may contain a publisher that queries external data when it appears. The publisher is automatically cancelled when the view disappears by default, or when the view itself is cleaned up.

# Work Performed
* Added `View.onAppear(dispatch:cancelOnDisappear:)`.
* Store now emits a didChange event on the action plan itself.