### PR TITLE
Fix inconsistency with the move method of OrderedState<_>

### DIFF
--- a/Sources/SwiftDux/State/OrderedState.swift
+++ b/Sources/SwiftDux/State/OrderedState.swift
@@ -281,7 +281,7 @@ public struct OrderedState<Substate>: StateType where Substate: IdentifiableStat
     let copy = copyStorageIfNeeded()
     let index = Swift.max(Swift.min(index, copy.orderOfIds.count), 0)
     let ids = Array(indexSet.map { copy.orderOfIds[$0] })
-    let offset = Swift.max(indexSet.reduce(0) { (result, i) in i < index ? result + 1 : result } - 1, 0)
+    let offset = Swift.max(indexSet.reduce(0) { (result, i) in i < index ? result + 1 : result }, 0)
     copy.orderOfIds.remove(at: indexSet)
     copy.orderOfIds.insert(contentsOf: ids, at: index - offset)
     self.storage = copy

--- a/Tests/SwiftDuxTests/PerformanceTests.swift
+++ b/Tests/SwiftDuxTests/PerformanceTests.swift
@@ -14,7 +14,7 @@ final class PerformanceTests: XCTestCase {
       
       let firstMoveItem = store.state.todoLists["123"]?.todos.values[300]
       store.send(TodoListAction.moveTodos(inList: "123", from: IndexSet(300...5000), to: 8000))
-      XCTAssertEqual(firstMoveItem?.id, store.state.todoLists["123"]?.todos.values[3300].id)
+      XCTAssertEqual(firstMoveItem?.id, store.state.todoLists["123"]?.todos.values[3299].id)
       
       let firstUndeletedItem = store.state.todoLists["123"]?.todos.values[3001]
       store.send(TodoListAction.removeTodos(fromList: "123", at: IndexSet(100...3000)))

--- a/Tests/SwiftDuxTests/State/OrderedStateTests.swift
+++ b/Tests/SwiftDuxTests/State/OrderedStateTests.swift
@@ -83,7 +83,7 @@ final class OrderedStateTests: XCTestCase {
   
   func testMoveOneUserFoward() {
     var state = OrderedState(bob, bill, john)
-    state.move(from: IndexSet([1]), to: 2)
+    state.move(from: IndexSet([1]), to: 3)
     XCTAssertEqual(state.values, [bob, john, bill])
   }
   
@@ -95,7 +95,7 @@ final class OrderedStateTests: XCTestCase {
   
   func testMoveTwoUsersFoward() {
     var state = OrderedState(bob, bill, john)
-    state.move(from: IndexSet([0,1]), to: 2)
+    state.move(from: IndexSet([0,1]), to: 3)
     XCTAssertEqual(state.values, [john, bob, bill])
   }
   


### PR DESCRIPTION
This PR fixes a bug that made the move method incompatible with SwiftUI's expectations.