### PR TITLE
2-way Binding Support

### DIFF
--- a/Sources/SwiftDux/UI/Connectable.swift
+++ b/Sources/SwiftDux/UI/Connectable.swift
@@ -20,6 +20,16 @@ public protocol Connectable {
   /// - Returns: The state if possible.
   func map(state: Superstate) -> State?
 
+  /// Map a superstate to the state needed by the view using the provided parameter.
+  ///
+  /// The method can return nil until the state becomes available. While it is nil, the view
+  /// will not be rendered.
+  /// - Parameters:
+  ///   - state: The superstate provided to the view from a superview.
+  ///   - binder: Helper that creates Binding types beteen the state and a dispatcable action
+  /// - Returns: The state if possible.
+  func map(state: Superstate, binder: StateBinder) -> State?
+
 }
 
 extension Connectable {
@@ -27,6 +37,16 @@ extension Connectable {
   /// Default implementation disables updates by action.
   public func updateWhen(action: Action) -> Bool {
     action is NoUpdateAction
+  }
+
+  /// Default implementation. Returns nil.
+  public func map(state: Superstate) -> State? {
+    nil
+  }
+
+  /// Default implementation. Calls the other map function.
+  public func map(state: Superstate, binder: StateBinder) -> State? {
+    map(state: state)
   }
 
 }

--- a/Sources/SwiftDux/UI/ParameterizedConnectable.swift
+++ b/Sources/SwiftDux/UI/ParameterizedConnectable.swift
@@ -23,6 +23,15 @@ public protocol ParameterizedConnectable {
   /// - Returns: The state if possible.
   func map(state: Superstate, with parameter: Parameter) -> State?
 
+  /// The method can return nil until the state becomes available. While it is nil, the view
+  /// will not be rendered.
+  /// - Parameters
+  ///   - state: The superstate provided to the view from a superview.
+  ///   - parameter: A user defined parameter required to retrieve the state.
+  ///   - binder: Helper that creates Binding types beteen the state and a dispatcable action
+  /// - Returns: The state if possible.
+  func map(state: Superstate, with parameter: Parameter, binder: StateBinder) -> State?
+
 }
 
 extension ParameterizedConnectable {
@@ -30,6 +39,16 @@ extension ParameterizedConnectable {
   /// Default implementation disables updates by action.
   public func updateWhen(action: Action, with parameter: Parameter) -> Bool {
     action is NoUpdateAction
+  }
+
+  /// Default implementation. Returns nil.
+  public func map(state: Superstate, with parameter: Parameter) -> State? {
+    nil
+  }
+
+  /// Default implementation. Calls the other map function.
+  public func map(state: Superstate, with parameter: Parameter, binder: StateBinder) -> State? {
+    map(state: state, with: parameter)
   }
 
 }
@@ -45,7 +64,7 @@ extension ParameterizedConnectable where Self: View {
   public func connect(with parameter: Parameter) -> some View {
     self.connect(
       updateWhen: { [updateWhen] in updateWhen($0, parameter) },
-      mapState: { [map] in map($0, parameter) }
+      mapState: { self.map(state: $0, with: parameter, binder: $1) }
     )
   }
 

--- a/Sources/SwiftDux/UI/StateBinder.swift
+++ b/Sources/SwiftDux/UI/StateBinder.swift
@@ -20,8 +20,8 @@ public struct StateBinder {
   /// Create a binding between a given state and an action.
   ///
   /// - Parameters:
-  ///   - get: The state to retrieve.
-  ///   - dispatch: Given a new version of the state, it returns an action to dispatch.
+  ///   - getState: The state to retrieve.
+  ///   - getAction: Given a new version of the state, it returns an action to dispatch.
   /// - Returns: A new Binding object.
   public func bind<T>(_ getState: @autoclosure @escaping () -> T, dispatch getAction: @escaping (T) -> Action?) -> Binding<T> {
     Binding<T>(

--- a/Sources/SwiftDux/UI/StateBinder.swift
+++ b/Sources/SwiftDux/UI/StateBinder.swift
@@ -1,0 +1,31 @@
+import Foundation
+import SwiftUI
+
+/// Binds a state to an action for use by controls that expect a two-way binding type such as TextFields.
+///
+/// ```
+/// func map(state: AppState, binder: StateBinder) -> Props? {
+///   Props(
+///     todos: state.todos,
+///     orderBy: binder.bind(state.orderBy) { TodoListAction.setOrderBy($0) }
+///   )
+/// }
+/// ```
+public struct StateBinder {
+
+  internal var actionDispatcher: ActionDispatcher
+
+  /// Create a binding between a given state and an action.
+  ///
+  /// - Parameters:
+  ///   - get: The state to retrieve.
+  ///   - dispatch: Given a new version of the state, it returns an action to dispatch.
+  /// - Returns: A new Binding object.
+  public func bind<T>(_ get: @autoclosure @escaping () -> T, dispatch: @escaping (T) -> Action) -> Binding<T> {
+    Binding<T>(
+      get: get,
+      set: { self.actionDispatcher.send(dispatch($0)) }
+    )
+  }
+
+}

--- a/Sources/SwiftDux/UI/StateBinder.swift
+++ b/Sources/SwiftDux/UI/StateBinder.swift
@@ -1,7 +1,9 @@
 import Foundation
 import SwiftUI
 
-/// Binds a state to an action for use by controls that expect a two-way binding type such as TextFields.
+/// Binds a state to a setter based action for use by controls that expect a two-way binding value such as TextFields.
+/// This is useful for simple actions that are expected to be dispatched many times a second. It should be avoided by any
+/// complicated or asynchronous actions.
 ///
 /// ```
 /// func map(state: AppState, binder: StateBinder) -> Props? {
@@ -21,11 +23,11 @@ public struct StateBinder {
   ///   - get: The state to retrieve.
   ///   - dispatch: Given a new version of the state, it returns an action to dispatch.
   /// - Returns: A new Binding object.
-  public func bind<T>(_ get: @autoclosure @escaping () -> T, dispatch: @escaping (T) -> Action?) -> Binding<T> {
+  public func bind<T>(_ getState: @autoclosure @escaping () -> T, dispatch getAction: @escaping (T) -> Action?) -> Binding<T> {
     Binding<T>(
-      get: get,
+      get: getState,
       set: { [actionDispatcher] in
-        guard let action = dispatch($0) else { return }
+        guard let action = getAction($0) else { return }
         actionDispatcher.send(action)
       }
     )

--- a/Sources/SwiftDux/UI/StateBinder.swift
+++ b/Sources/SwiftDux/UI/StateBinder.swift
@@ -21,10 +21,13 @@ public struct StateBinder {
   ///   - get: The state to retrieve.
   ///   - dispatch: Given a new version of the state, it returns an action to dispatch.
   /// - Returns: A new Binding object.
-  public func bind<T>(_ get: @autoclosure @escaping () -> T, dispatch: @escaping (T) -> Action) -> Binding<T> {
+  public func bind<T>(_ get: @autoclosure @escaping () -> T, dispatch: @escaping (T) -> Action?) -> Binding<T> {
     Binding<T>(
       get: get,
-      set: { self.actionDispatcher.send(dispatch($0)) }
+      set: { [actionDispatcher] in
+        guard let action = dispatch($0) else { return }
+        actionDispatcher.send(action)
+      }
     )
   }
 


### PR DESCRIPTION
This PR adds a convenient API to provide better support of SwiftUI views that use Binding<_> for their arguments. It combines a state value with a setter-based action that is expected to update it.

# Work Performed
- Added StateBinder
- Added new API to Connectable and ParameterizedConnectable to include StateBinder when mapping the application state to a view.
