### PR TITLE
Fix Stale UI When Using ActionDispatcher In Some Cases

### DIFF
--- a/Sources/SwiftDux/UI/MappedState.swift
+++ b/Sources/SwiftDux/UI/MappedState.swift
@@ -16,6 +16,10 @@ public struct MappedState<State>: DynamicProperty {
 
   @EnvironmentObject private var connection: StateConnection<State>
 
+  // Needed by SwiftUI in case StateBinder is used. This attaches the required
+  // subscriptions.
+  @Environment(\.actionDispatcher) private var actionDispatcher: ActionDispatcher
+
   public var wrappedValue: State {
     connection.latestState!
   }

--- a/Sources/SwiftDux/UI/StateConnection.swift
+++ b/Sources/SwiftDux/UI/StateConnection.swift
@@ -6,17 +6,16 @@ import Foundation
 /// It uses a "change publisher" to notify it to retrieve a new version of the state object. This publisher
 /// typically fires from the store after the state has been modified, or directly from an action being dispatched.
 internal final class StateConnection<State>: ObservableObject, Identifiable {
-
   @Published var latestState: State?
 
   var getState: () -> State?
 
   private var cancellable: Cancellable? = nil
 
-  init(getState: @escaping () -> State?, changePublisher: AnyPublisher<Void, Never>) {
+  init(getState: @escaping () -> State?, changePublisher: AnyPublisher<Void, Never>? = nil) {
     self.getState = getState
     self.latestState = getState()
-    self.cancellable = changePublisher.sink { [weak self] in
+    self.cancellable = changePublisher?.sink { [weak self] in
       guard let self = self else { return }
       self.latestState = getState()
     }

--- a/Sources/SwiftDux/UI/ViewModifiers/StateConnectionViewModifier.swift
+++ b/Sources/SwiftDux/UI/ViewModifiers/StateConnectionViewModifier.swift
@@ -41,7 +41,7 @@ internal struct StateConnectionViewModifier<Superstate, State>: ViewModifier {
       },
       changePublisher: hasUpdate
         ? storeUpdated.filter(filter).map { _ in }.eraseToAnyPublisher()
-        : dispatchConnection.didDispatchAction.eraseToAnyPublisher()
+        : nil
     )
     return stateConnection
   }


### PR DESCRIPTION
This PR fixes cases where the View fails to refresh correctly after dispatching an action. The exact cause is unknown, but is due to internal implementation details of SwiftUI.

To fix this problem, the actionDispatcher is now added to the MappedState itself as an environment value. It's unused by MappedState, but SwiftUI will still attach subscribers to it. This replaces the manual subscription that published updates to the corresponding StateConnection<_>. For some unknown reason, this would stop working after one or more refreshes.