### PR TITLE
Re-render the view when a referenced-based binding is updated.

### DIFF
--- a/Sources/SwiftDux/UI/MappedState.swift
+++ b/Sources/SwiftDux/UI/MappedState.swift
@@ -16,10 +16,6 @@ public struct MappedState<State>: DynamicProperty where State: Equatable {
 
   @EnvironmentObject private var connection: StateConnection<State>
 
-  // Needed by SwiftUI in case StateBinder is used. This attaches the required
-  // subscriptions.
-  @Environment(\.actionDispatcher) private var actionDispatcher: ActionDispatcher
-
   public var wrappedValue: State {
     guard let state = connection.state else {
       fatalError("State was not connected before using @MappedState")

--- a/Sources/SwiftDux/UI/StateBinder.swift
+++ b/Sources/SwiftDux/UI/StateBinder.swift
@@ -19,12 +19,12 @@ public struct StateBinder {
   /// Create a binding between a given state and an action.
   ///
   /// - Parameters:
-  ///   - getState: The state to retrieve.
+  ///   - state: The state to retrieve.
   ///   - getAction: Given a new version of the state, it returns an action to dispatch.
   /// - Returns: A new Binding object.
-  public func bind<T>(_ getState: @autoclosure @escaping () -> T, dispatch getAction: @escaping (T) -> Action?) -> Binding<T> {
+  public func bind<T>(_ state: T, dispatch getAction: @escaping (T) -> Action?) -> Binding<T> {
     Binding<T>(
-      get: getState,
+      get: { state },
       set: { [actionDispatcher] in
         guard let action = getAction($0) else { return }
         actionDispatcher.send(action)


### PR DESCRIPTION
# Work Performed
- Removed unneeded auto-closure, so the value will change properly if a reference type is used.
- Removed unneeded reference to the ActionDispatcher.