### PR TITLE
Added ability to bind an action to a function

### DIFF
--- a/Sources/SwiftDux/UI/ActionBinder.swift
+++ b/Sources/SwiftDux/UI/ActionBinder.swift
@@ -26,11 +26,79 @@ public struct ActionBinder {
   @inlinable public func bind<T>(_ state: T, dispatch getAction: @escaping (T) -> Action?) -> ActionBinding<T> {
     ActionBinding(
       value: state,
-      set: { [actionDispatcher] in
-        guard let action = getAction($0) else { return }
-        actionDispatcher.send(action)
+      set: {
+        self.dispatch(getAction($0))
       }
     )
+  }
+
+  /// Create a function binding that dispatches an action.
+  ///
+  /// - Parameter getAction: A closure that returns an action to dispatch.
+  /// - Returns: a function that dispatches the action.
+  @inlinable public func bind(dispatch getAction: @escaping () -> Action?) -> () -> Void {
+    { self.dispatch(getAction()) }
+  }
+
+  /// Create a function binding that dispatches an action.
+  ///
+  /// - Parameter getAction: A closure that returns an action to dispatch.
+  /// - Returns: a function that dispatches the action.
+  @inlinable public func bind<P0>(dispatch getAction: @escaping (P0) -> Action?) -> (P0) -> Void {
+    { self.dispatch(getAction($0)) }
+  }
+
+  /// Create a function binding that dispatches an action.
+  ///
+  /// - Parameter getAction: A closure that returns an action to dispatch.
+  /// - Returns: a function that dispatches the action.
+  @inlinable public func bind<P0, P1>(dispatch getAction: @escaping (P0, P1) -> Action?) -> (P0, P1) -> Void {
+    { self.dispatch(getAction($0, $1)) }
+  }
+
+  /// Create a function binding that dispatches an action.
+  ///
+  /// - Parameter getAction: A closure that returns an action to dispatch.
+  /// - Returns: a function that dispatches the action.
+  @inlinable public func bind<P0, P1, P2>(
+    dispatch getAction: @escaping (P0, P1, P2) -> Action?
+  ) -> (P0, P1, P2) -> Void {
+    { self.dispatch(getAction($0, $1, $2)) }
+  }
+
+  /// Create a function binding that dispatches an action.
+  ///
+  /// - Parameter getAction: A closure that returns an action to dispatch.
+  /// - Returns: a function that dispatches the action.
+  @inlinable public func bind<P0, P1, P2, P3>(
+    dispatch getAction: @escaping (P0, P1, P2, P3) -> Action?
+  ) -> (P0, P1, P2, P3) -> Void {
+    { self.dispatch(getAction($0, $1, $2, $3)) }
+  }
+
+  /// Create a function binding that dispatches an action.
+  ///
+  /// - Parameter getAction: A closure that returns an action to dispatch.
+  /// - Returns: a function that dispatches the action.
+  @inlinable public func bind<P0, P1, P2, P3, P4>(
+    dispatch getAction: @escaping (P0, P1, P2, P3, P4) -> Action?
+  ) -> (P0, P1, P2, P3, P4) -> Void {
+    { self.dispatch(getAction($0, $1, $2, $3, $4)) }
+  }
+
+  /// Create a function binding that dispatches an action.
+  ///
+  /// - Parameter getAction: A closure that returns an action to dispatch.
+  /// - Returns: a function that dispatches the action.
+  @inlinable public func bind<P0, P1, P2, P3, P4, P5>(
+    dispatch getAction: @escaping (P0, P1, P2, P3, P4, P5) -> Action?
+  ) -> (P0, P1, P2, P3, P4, P5) -> Void {
+    { self.dispatch(getAction($0, $1, $2, $3, $4, $5)) }
+  }
+
+  @usableFromInline internal func dispatch(_ action: Action?) {
+    guard let action = action else { return }
+    actionDispatcher.send(action)
   }
 }
 

--- a/Sources/SwiftDux/UI/ActionBinding.swift
+++ b/Sources/SwiftDux/UI/ActionBinding.swift
@@ -10,7 +10,8 @@ public struct ActionBinding<Value> {
 
   /// The current value of the binding.
   @inlinable public var wrappedValue: Value {
-    projectedValue.wrappedValue
+    get { projectedValue.wrappedValue }
+    set { projectedValue.wrappedValue = newValue }
   }
 
   @inlinable internal init(value: Value, set: @escaping (Value) -> Void) {

--- a/Tests/SwiftDuxTests/UI/ActionBinderTests.swift
+++ b/Tests/SwiftDuxTests/UI/ActionBinderTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+import Combine
+import SwiftUI
+@testable import SwiftDux
+
+final class ActionBinderTests: XCTestCase {
+  var store: Store<TestState>!
+  var binder: ActionBinder!
+  
+  override func setUp() {
+    self.store = Store(state: TestState(), reducer: TestReducer())
+    self.binder = ActionBinder(actionDispatcher: store)
+  }
+  
+  func testInitialState() {
+    XCTAssertEqual(store.state.name, "")
+  }
+  
+  func testBindingState() {
+    var binding = binder.bind(store.state.name) {
+      TestAction.setName($0)
+    }
+    binding.wrappedValue = "new value"
+    XCTAssertEqual(store.state.name, "new value")
+  }
+  
+  func testBindingActionWithNoParameters() {
+    let onSetName: ()->() = binder.bind { TestAction.setName("0") }
+    onSetName()
+    XCTAssertEqual(store.state.name, "0")
+  }
+  
+  func testBindingActionWithParameters1() {
+    let onSetName: (String)->() = binder.bind { TestAction.setName($0) }
+    onSetName("1")
+    XCTAssertEqual(store.state.name, "1")
+  }
+  
+  func testBindingActionWithParameters2() {
+    let onSetName: (String, Int)->() = binder.bind { TestAction.setName("\($0) \($1)") }
+    onSetName("1", 2)
+    XCTAssertEqual(store.state.name, "1 2")
+  }
+  
+  func testBindingActionWithParameters3() {
+    let onSetName: (String, Int, Float)->() = binder.bind { TestAction.setName("\($0) \($1) \($2)") }
+    onSetName("1", 2, 3.1)
+    XCTAssertEqual(store.state.name, "1 2 3.1")
+  }
+  
+  func testBindingActionWithParameters4() {
+    let onSetName: (String, Int, Float, Color)->() = binder.bind { TestAction.setName("\($0) \($1) \($2) \($3)") }
+    onSetName("1", 2, 3.1, Color.red)
+    XCTAssertEqual(store.state.name, "1 2 3.1 red")
+  }
+  
+  func testBindingActionWithParameters5() {
+    let onSetName: (String, Int, Float, Color, CGPoint)->() = binder.bind { TestAction.setName("\($0) \($1) \($2) \($3) \($4)") }
+    onSetName("1", 2, 3.1, Color.red, CGPoint(x: 10, y: 5))
+    XCTAssertEqual(store.state.name, "1 2 3.1 red (10.0, 5.0)")
+  }
+  
+  func testBindingActionWithParameters6() {
+    let onSetName: (String, Int, Float, Color, CGPoint, CGSize)->() = binder.bind { TestAction.setName("\($0) \($1) \($2) \($3) \($4) \($5)") }
+    onSetName("1", 2, 3.1, Color.red, CGPoint(x: 10, y: 5), CGSize(width: 25, height: 30))
+    XCTAssertEqual(store.state.name, "1 2 3.1 red (10.0, 5.0) (25.0, 30.0)")
+  }
+}
+
+extension ActionBinderTests {
+  
+  struct TestState {
+    var name: String = ""
+  }
+  
+  enum TestAction: Action {
+    case setName(String)
+  }
+  
+  final class TestReducer: Reducer {
+    func reduce(state: TestState, action: TestAction) -> TestState {
+      var state = state
+      switch action {
+      case .setName(let name):
+        state.name = name
+      }
+      return state
+    }
+  }
+}


### PR DESCRIPTION
This PR reduces the need of `@MappedDispatch` and function handlers in views that simply dispatch an action.

# Work Performed
- Added API to build functions from `ActionBinder<_>` that dispatch actions.