### PR TITLE
Support Equatable for Closure Bindings on ConnectableView's Props Type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,20 +215,22 @@ TodoDetailsView(id: "123")
 
 ## ActionBinding<_>
 
-SwiftUI has a focus on two-way bindings that connect to a single value source. To support updates through actions, SwiftDux provides a convenient API in the `ConnectableView` protocol using an `ActionBinder` object. Use the `map(state:binder:)` method on the protocol as shown below. It provides a value to the text field, and dispatches an action when the text value changes.
+SwiftUI has a focus on two-way bindings that connect to a single value source. To support updates through actions, SwiftDux provides a convenient API in the `ConnectableView` protocol using an `ActionBinder` object. Use the `map(state:binder:)` method on the protocol as shown below. It provides a value to the text field, and dispatches an action when the text value changes. It also binds a function to a dispatchable action.
 
 ```swift
 struct LoginForm: View {
 
   struct Props: Equatable {
     @ActionBinding var email: String
+    @ActionBinding var onSubmit: ()->()
   }
 
   func map(state: AppState, binder: ActionBinder) -> Props? {
     Props(
       email: binder.bind(state.loginForm.email) { 
         LoginFormAction.setEmail($0)
-      }
+      },
+      onSubmit: binder.bind(LoginFormAction.submit)
     )
   }
 
@@ -236,6 +238,9 @@ struct LoginForm: View {
     VStack {
       TextField("Email", text: $props.email)
       /* ... */
+      Button(action: props.onSubmit) {
+        Text("Submit")
+      }
     }
   }
 }

--- a/Sources/SwiftDux/UI/ActionBinder.swift
+++ b/Sources/SwiftDux/UI/ActionBinder.swift
@@ -23,9 +23,10 @@ public struct ActionBinder {
   ///   - state: The state to retrieve.
   ///   - getAction: Given a new version of the state, it returns an action to dispatch.
   /// - Returns: A new Binding object.
-  @inlinable public func bind<T>(_ state: T, dispatch getAction: @escaping (T) -> Action?) -> ActionBinding<T> {
+  @inlinable public func bind<T>(_ state: T, dispatch getAction: @escaping (T) -> Action?) -> ActionBinding<T> where T: Equatable {
     ActionBinding(
       value: state,
+      isEqual: { state == $0 },
       set: {
         self.dispatch(getAction($0))
       }
@@ -36,24 +37,24 @@ public struct ActionBinder {
   ///
   /// - Parameter getAction: A closure that returns an action to dispatch.
   /// - Returns: a function that dispatches the action.
-  @inlinable public func bind(dispatch getAction: @escaping () -> Action?) -> () -> Void {
-    { self.dispatch(getAction()) }
+  @inlinable public func bind(dispatch getAction: @escaping () -> Action?) -> ActionBinding<() -> Void> {
+    .constant { self.dispatch(getAction()) }
   }
 
   /// Create a function binding that dispatches an action.
   ///
   /// - Parameter getAction: A closure that returns an action to dispatch.
   /// - Returns: a function that dispatches the action.
-  @inlinable public func bind<P0>(dispatch getAction: @escaping (P0) -> Action?) -> (P0) -> Void {
-    { self.dispatch(getAction($0)) }
+  @inlinable public func bind<P0>(dispatch getAction: @escaping (P0) -> Action?) -> ActionBinding<(P0) -> Void> {
+    .constant { self.dispatch(getAction($0)) }
   }
 
   /// Create a function binding that dispatches an action.
   ///
   /// - Parameter getAction: A closure that returns an action to dispatch.
   /// - Returns: a function that dispatches the action.
-  @inlinable public func bind<P0, P1>(dispatch getAction: @escaping (P0, P1) -> Action?) -> (P0, P1) -> Void {
-    { self.dispatch(getAction($0, $1)) }
+  @inlinable public func bind<P0, P1>(dispatch getAction: @escaping (P0, P1) -> Action?) -> ActionBinding<(P0, P1) -> Void> {
+    .constant { self.dispatch(getAction($0, $1)) }
   }
 
   /// Create a function binding that dispatches an action.
@@ -62,8 +63,8 @@ public struct ActionBinder {
   /// - Returns: a function that dispatches the action.
   @inlinable public func bind<P0, P1, P2>(
     dispatch getAction: @escaping (P0, P1, P2) -> Action?
-  ) -> (P0, P1, P2) -> Void {
-    { self.dispatch(getAction($0, $1, $2)) }
+  ) -> ActionBinding<(P0, P1, P2) -> Void> {
+    .constant { self.dispatch(getAction($0, $1, $2)) }
   }
 
   /// Create a function binding that dispatches an action.
@@ -72,8 +73,8 @@ public struct ActionBinder {
   /// - Returns: a function that dispatches the action.
   @inlinable public func bind<P0, P1, P2, P3>(
     dispatch getAction: @escaping (P0, P1, P2, P3) -> Action?
-  ) -> (P0, P1, P2, P3) -> Void {
-    { self.dispatch(getAction($0, $1, $2, $3)) }
+  ) -> ActionBinding<(P0, P1, P2, P3) -> Void> {
+    .constant { self.dispatch(getAction($0, $1, $2, $3)) }
   }
 
   /// Create a function binding that dispatches an action.
@@ -82,8 +83,8 @@ public struct ActionBinder {
   /// - Returns: a function that dispatches the action.
   @inlinable public func bind<P0, P1, P2, P3, P4>(
     dispatch getAction: @escaping (P0, P1, P2, P3, P4) -> Action?
-  ) -> (P0, P1, P2, P3, P4) -> Void {
-    { self.dispatch(getAction($0, $1, $2, $3, $4)) }
+  ) -> ActionBinding<(P0, P1, P2, P3, P4) -> Void> {
+    .constant { self.dispatch(getAction($0, $1, $2, $3, $4)) }
   }
 
   /// Create a function binding that dispatches an action.
@@ -92,8 +93,8 @@ public struct ActionBinder {
   /// - Returns: a function that dispatches the action.
   @inlinable public func bind<P0, P1, P2, P3, P4, P5>(
     dispatch getAction: @escaping (P0, P1, P2, P3, P4, P5) -> Action?
-  ) -> (P0, P1, P2, P3, P4, P5) -> Void {
-    { self.dispatch(getAction($0, $1, $2, $3, $4, $5)) }
+  ) -> ActionBinding<(P0, P1, P2, P3, P4, P5) -> Void> {
+    .constant { self.dispatch(getAction($0, $1, $2, $3, $4, $5)) }
   }
 
   @usableFromInline internal func dispatch(_ action: Action?) {

--- a/Sources/SwiftDux/UI/ActionBinder.swift
+++ b/Sources/SwiftDux/UI/ActionBinder.swift
@@ -37,7 +37,7 @@ public struct ActionBinder {
   ///
   /// - Parameter getAction: A closure that returns an action to dispatch.
   /// - Returns: a function that dispatches the action.
-  @inlinable public func bind(dispatch getAction: @escaping () -> Action?) -> ActionBinding<() -> Void> {
+  @inlinable public func bind(_ getAction: @escaping () -> Action?) -> ActionBinding<() -> Void> {
     .constant { self.dispatch(getAction()) }
   }
 
@@ -45,7 +45,7 @@ public struct ActionBinder {
   ///
   /// - Parameter getAction: A closure that returns an action to dispatch.
   /// - Returns: a function that dispatches the action.
-  @inlinable public func bind<P0>(dispatch getAction: @escaping (P0) -> Action?) -> ActionBinding<(P0) -> Void> {
+  @inlinable public func bind<P0>(_ getAction: @escaping (P0) -> Action?) -> ActionBinding<(P0) -> Void> {
     .constant { self.dispatch(getAction($0)) }
   }
 
@@ -53,7 +53,7 @@ public struct ActionBinder {
   ///
   /// - Parameter getAction: A closure that returns an action to dispatch.
   /// - Returns: a function that dispatches the action.
-  @inlinable public func bind<P0, P1>(dispatch getAction: @escaping (P0, P1) -> Action?) -> ActionBinding<(P0, P1) -> Void> {
+  @inlinable public func bind<P0, P1>(_ getAction: @escaping (P0, P1) -> Action?) -> ActionBinding<(P0, P1) -> Void> {
     .constant { self.dispatch(getAction($0, $1)) }
   }
 
@@ -62,7 +62,7 @@ public struct ActionBinder {
   /// - Parameter getAction: A closure that returns an action to dispatch.
   /// - Returns: a function that dispatches the action.
   @inlinable public func bind<P0, P1, P2>(
-    dispatch getAction: @escaping (P0, P1, P2) -> Action?
+    _ getAction: @escaping (P0, P1, P2) -> Action?
   ) -> ActionBinding<(P0, P1, P2) -> Void> {
     .constant { self.dispatch(getAction($0, $1, $2)) }
   }
@@ -72,7 +72,7 @@ public struct ActionBinder {
   /// - Parameter getAction: A closure that returns an action to dispatch.
   /// - Returns: a function that dispatches the action.
   @inlinable public func bind<P0, P1, P2, P3>(
-    dispatch getAction: @escaping (P0, P1, P2, P3) -> Action?
+    _ getAction: @escaping (P0, P1, P2, P3) -> Action?
   ) -> ActionBinding<(P0, P1, P2, P3) -> Void> {
     .constant { self.dispatch(getAction($0, $1, $2, $3)) }
   }
@@ -82,7 +82,7 @@ public struct ActionBinder {
   /// - Parameter getAction: A closure that returns an action to dispatch.
   /// - Returns: a function that dispatches the action.
   @inlinable public func bind<P0, P1, P2, P3, P4>(
-    dispatch getAction: @escaping (P0, P1, P2, P3, P4) -> Action?
+    _ getAction: @escaping (P0, P1, P2, P3, P4) -> Action?
   ) -> ActionBinding<(P0, P1, P2, P3, P4) -> Void> {
     .constant { self.dispatch(getAction($0, $1, $2, $3, $4)) }
   }
@@ -92,7 +92,7 @@ public struct ActionBinder {
   /// - Parameter getAction: A closure that returns an action to dispatch.
   /// - Returns: a function that dispatches the action.
   @inlinable public func bind<P0, P1, P2, P3, P4, P5>(
-    dispatch getAction: @escaping (P0, P1, P2, P3, P4, P5) -> Action?
+    _ getAction: @escaping (P0, P1, P2, P3, P4, P5) -> Action?
   ) -> ActionBinding<(P0, P1, P2, P3, P4, P5) -> Void> {
     .constant { self.dispatch(getAction($0, $1, $2, $3, $4, $5)) }
   }

--- a/Tests/SwiftDuxTests/UI/ActionBinderTests.swift
+++ b/Tests/SwiftDuxTests/UI/ActionBinderTests.swift
@@ -25,44 +25,44 @@ final class ActionBinderTests: XCTestCase {
   }
   
   func testBindingActionWithNoParameters() {
-    let onSetName: ()->() = binder.bind { TestAction.setName("0") }
-    onSetName()
+    let binding: ActionBinding<()->()> = binder.bind { TestAction.setName("0") }
+    binding.wrappedValue()
     XCTAssertEqual(store.state.name, "0")
   }
   
   func testBindingActionWithParameters1() {
-    let onSetName: (String)->() = binder.bind { TestAction.setName($0) }
-    onSetName("1")
+    let binding: ActionBinding<(String)->()> = binder.bind { TestAction.setName($0) }
+    binding.wrappedValue("1")
     XCTAssertEqual(store.state.name, "1")
   }
   
   func testBindingActionWithParameters2() {
-    let onSetName: (String, Int)->() = binder.bind { TestAction.setName("\($0) \($1)") }
-    onSetName("1", 2)
+    let binding: ActionBinding<(String, Int)->()> = binder.bind { TestAction.setName("\($0) \($1)") }
+    binding.wrappedValue("1", 2)
     XCTAssertEqual(store.state.name, "1 2")
   }
   
   func testBindingActionWithParameters3() {
-    let onSetName: (String, Int, Float)->() = binder.bind { TestAction.setName("\($0) \($1) \($2)") }
-    onSetName("1", 2, 3.1)
+    let binding: ActionBinding<(String, Int, Float)->()> = binder.bind { TestAction.setName("\($0) \($1) \($2)") }
+    binding.wrappedValue("1", 2, 3.1)
     XCTAssertEqual(store.state.name, "1 2 3.1")
   }
   
   func testBindingActionWithParameters4() {
-    let onSetName: (String, Int, Float, Color)->() = binder.bind { TestAction.setName("\($0) \($1) \($2) \($3)") }
-    onSetName("1", 2, 3.1, Color.red)
+    let binding: ActionBinding<(String, Int, Float, Color)->()> = binder.bind { TestAction.setName("\($0) \($1) \($2) \($3)") }
+    binding.wrappedValue("1", 2, 3.1, Color.red)
     XCTAssertEqual(store.state.name, "1 2 3.1 red")
   }
   
   func testBindingActionWithParameters5() {
-    let onSetName: (String, Int, Float, Color, CGPoint)->() = binder.bind { TestAction.setName("\($0) \($1) \($2) \($3) \($4)") }
-    onSetName("1", 2, 3.1, Color.red, CGPoint(x: 10, y: 5))
+    let binding: ActionBinding<(String, Int, Float, Color, CGPoint)->()> = binder.bind { TestAction.setName("\($0) \($1) \($2) \($3) \($4)") }
+    binding.wrappedValue("1", 2, 3.1, Color.red, CGPoint(x: 10, y: 5))
     XCTAssertEqual(store.state.name, "1 2 3.1 red (10.0, 5.0)")
   }
   
   func testBindingActionWithParameters6() {
-    let onSetName: (String, Int, Float, Color, CGPoint, CGSize)->() = binder.bind { TestAction.setName("\($0) \($1) \($2) \($3) \($4) \($5)") }
-    onSetName("1", 2, 3.1, Color.red, CGPoint(x: 10, y: 5), CGSize(width: 25, height: 30))
+    let binding: ActionBinding<(String, Int, Float, Color, CGPoint, CGSize)->()> = binder.bind { TestAction.setName("\($0) \($1) \($2) \($3) \($4) \($5)") }
+    binding.wrappedValue("1", 2, 3.1, Color.red, CGPoint(x: 10, y: 5), CGSize(width: 25, height: 30))
     XCTAssertEqual(store.state.name, "1 2 3.1 red (10.0, 5.0) (25.0, 30.0)")
   }
 }


### PR DESCRIPTION
The `ActionBinder` can return closures that bind to a dispatchable action, but this breaks the synthesized support of Equatable on the Props associated type for ConnectableView. Instead, this PR wraps the closures in an ActionBinding like all other bindings. This provides away to check for equability internally. For closures, this will always return "true".

# Worker Performed
- Updated `ActionBinder` to return an `ActionBinding` for all bind functions.
- Added an isEqual property to `ActionBinding` as a hack around `Equatable` to allow closures to always return true.