### PR TITLE
Inject store by type

### DIFF
--- a/Sources/SwiftDux/UI/Connectable.swift
+++ b/Sources/SwiftDux/UI/Connectable.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// to a possible bug in Swift that throws an invalid assocated type if Props isn't explicitly typealiased.
 public protocol Connectable {
 
-  associatedtype Superstate: Equatable
+  associatedtype Superstate
   associatedtype Props: Equatable
 
   /// Causes the view to be updated based on a dispatched action.

--- a/Sources/SwiftDux/UI/Connector.swift
+++ b/Sources/SwiftDux/UI/Connector.swift
@@ -9,7 +9,7 @@ internal final class NoUpdateAction: Action {
 
 fileprivate let noUpdateAction = NoUpdateAction()
 
-internal struct Connector<Content, Superstate, Props>: View where Superstate: Equatable, Props: Equatable, Content: View {
+public struct Connector<Content, Superstate, Props>: View where Props: Equatable, Content: View {
   @EnvironmentObject private var storeWrapper: StoreWrapper<Superstate>
   @Environment(\.actionDispatcher) private var actionDispatcher
 
@@ -17,11 +17,11 @@ internal struct Connector<Content, Superstate, Props>: View where Superstate: Eq
   private var filter: ((Action) -> Bool)?
   private var mapProps: (Superstate, ActionBinder) -> Props?
 
-  private var store: Store<Superstate> {
+  private var store: StoreProxy<Superstate> {
     storeWrapper.store
   }
 
-  @usableFromInline internal init(
+  public init(
     content: @escaping (Props) -> Content,
     filter: ((Action) -> Bool)?,
     mapProps: @escaping (Superstate, ActionBinder) -> Props?
@@ -31,7 +31,7 @@ internal struct Connector<Content, Superstate, Props>: View where Superstate: Eq
     self.mapProps = mapProps
   }
 
-  var body: some View {
+  public var body: some View {
     ConnectorInner(content: content, initialProps: getProps(), propsPublisher: createPropsPublisher())
   }
 
@@ -63,7 +63,6 @@ internal struct Connector<Content, Superstate, Props>: View where Superstate: Eq
 internal struct ConnectorInner<Content, Props>: View where Props: Equatable, Content: View {
   private var content: (Props) -> Content
   private var propsPublisher: AnyPublisher<Props, Never>
-
   @State private var props: Props?
 
   internal init(content: @escaping (Props) -> Content, initialProps: Props?, propsPublisher: AnyPublisher<Props, Never>) {

--- a/Sources/SwiftDux/UI/MappedState.swift
+++ b/Sources/SwiftDux/UI/MappedState.swift
@@ -11,7 +11,7 @@ import SwiftUI
 /// }
 /// ```
 @propertyWrapper
-public struct MappedState<State>: DynamicProperty where State: Equatable {
+public struct MappedState<State>: DynamicProperty {
   @EnvironmentObject private var storeWrapper: StoreWrapper<State>
 
   public var wrappedValue: State {

--- a/Sources/SwiftDux/UI/StoreWrapper.swift
+++ b/Sources/SwiftDux/UI/StoreWrapper.swift
@@ -2,9 +2,9 @@ import Combine
 import SwiftUI
 
 internal final class StoreWrapper<State>: ObservableObject {
-  let store: Store<State>
+  let store: StoreProxy<State>
 
-  init(store: Store<State>) {
+  init(store: StoreProxy<State>) {
     self.store = store
   }
 }

--- a/Sources/SwiftDux/UI/ViewModifiers/StoreProviderViewModifier.swift
+++ b/Sources/SwiftDux/UI/ViewModifiers/StoreProviderViewModifier.swift
@@ -2,10 +2,10 @@ import Combine
 import SwiftUI
 
 /// A view modifier that injects a store into the environment.
-public struct StoreProviderViewModifier<State>: ViewModifier where State: StateType {
+public struct StoreProviderViewModifier<State>: ViewModifier {
   private var storeWrapper: StoreWrapper<State>
 
-  @usableFromInline internal init(store: Store<State>) {
+  @usableFromInline internal init(store: StoreProxy<State>) {
     self.storeWrapper = StoreWrapper(store: store)
   }
 
@@ -33,12 +33,35 @@ extension View {
   ///     RootAppNavigation()
   ///       .provideStore(store)
   ///   }
-  ///
   /// }
   /// ```
   /// - Parameter store: The store object to inject.
   /// - Returns: The modified view.
   @inlinable public func provideStore<State>(_ store: Store<State>) -> some View where State: StateType {
-    return modifier(StoreProviderViewModifier<State>(store: store))
+    return modifier(StoreProviderViewModifier<State>(store: store.proxy(for: State.self)!))
+  }
+
+  /// Injects a store into the environment as a specific type.
+  ///
+  /// This is useful if a protocol is used to retreive the state in a `ConnectableView`. It can be used multiple times
+  /// to provide support for protocols that the store might adhere to.
+  /// struct RootView: View {
+  ///   // Passed in from the AppDelegate or SceneDelegate class.
+  ///   var store: Store<AppState>
+  ///
+  ///
+  ///   var body: some View {
+  ///     RootAppNavigation()
+  ///       .provideStore(store)
+  ///       .provideStore(store, as: NavigationStateRoot.self)
+  ///   }
+  /// }
+  /// ```
+  /// - Parameters:
+  ///   - store: The store object to inject.
+  ///   - type: A type that the store adheres to.
+  /// - Returns: The modified view.
+  @inlinable public func provideStore<State, Substate>(_ store: Store<State>, as type: Substate.Type) -> some View where State: StateType {
+    return modifier(StoreProviderViewModifier<Substate>(store: store.proxy(for: type.self)!))
   }
 }


### PR DESCRIPTION
This allows 3rd party libraries to use protocols to represent their state, and access it within SwiftUI.

# Worker Performed
- Removed Equatable conformance where it's not used.
- Added new `View.provideStore<_>(_:as:)` to inject a store as a specific type.