### PR TITLE
Fix Type Inference

### DIFF
--- a/Sources/SwiftDux/Store/Store.swift
+++ b/Sources/SwiftDux/Store/Store.swift
@@ -59,7 +59,7 @@ public final class Store<State> {
   ///   - done: A closure called with an async action has completed.
   /// - Returns: A proxy object if the state type matches, otherwise nil.
   @inlinable public func proxy<T>(for stateType: T.Type, done: (() -> Void)? = nil) -> StoreProxy<T>? {
-    guard State.self is T.Type else { return nil }
+    guard state is T else { return nil }
     return StoreProxy<T>(
       getState: { [unowned self] in self.state as! T },
       didChange: didChange,

--- a/Sources/SwiftDux/UI/MappedState.swift
+++ b/Sources/SwiftDux/UI/MappedState.swift
@@ -18,7 +18,7 @@ public struct MappedState<State>: DynamicProperty {
 
   public var wrappedValue: State {
     guard let store = store else {
-      fatalError("SwiftDux Store<_> does not conform to type: \(State.self)")
+      fatalError("Tried mapping the state to a view, but the Store<_> doesn't conform to '\(State.self)'")
     }
     return store.state
   }

--- a/Tests/SwiftDuxTests/Store/StoreProxyTests.swift
+++ b/Tests/SwiftDuxTests/Store/StoreProxyTests.swift
@@ -17,6 +17,12 @@ final class StoreProxyTests: XCTestCase {
     XCTAssertEqual(proxy?.state.todoLists[1].name, "test")
   }
   
+  func testProxyWithProtocol() {
+    let store = configureStore()
+    let proxy = store.proxy(for: TodoListStateRoot.self)
+    XCTAssertNotNil(proxy)
+  }
+  
   static var allTests = [
     ("testAccessingState", testAccessingState),
     ("testSendingAction", testSendingAction),


### PR DESCRIPTION
# Work Performed
- Fix type inference broken after Swift 5.3.
- The UI now throws a fatal error if it can't retrieve the state instead of displaying a white screen.