### PR TITLE
Simplified Store Publisher

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         destination: 
-          - "platform=iOS Simulator,OS=13.4,name=iPhone 11"
+          - "platform=iOS Simulator,OS=14.0,name=iPhone 11"
           - "platform=OS X"
     steps:
       - name: Checkout
@@ -22,9 +22,9 @@ jobs:
         run: cd $GITHUB_WORKSPACE
       - name: Install tooling
         run: |
-          sudo xcode-select -s /Applications/Xcode_11.4.app
+          sudo xcode-select -s /Applications/Xcode_12.app
           brew install mint
-          mint install apple/swift-format@swift-5.2-branch
+          mint install apple/swift-format@0.50300.0
       - name: Check code formatting
         run: |
           swift-format -r -m lint Sources

--- a/Guides/Getting Started.md
+++ b/Guides/Getting Started.md
@@ -141,26 +141,9 @@ struct RootView: View {
 }
 ```
 
-## Passing Data to a Connectable View
-In some cases, a connected view needs external information to map the state to its props, such as an identifier. Simply add any needed variables to your view, and access them in the mapping function.
-
-```swift
-struct TodoDetailsView: ConnectableView {
-  var id: String
-
-  func map(state: TodoList) -> Todo? {
-    state[id]
-  }
-}
-
-// Somewhere else in the view hierarchy:
-
-TodoDetailsView(id: "123")
-```
-
 ## ActionBinding<_>
 
-SwiftUI has a focus on two-way bindings that connect to a single value source. To support updates through actions, SwiftDux provides a convenient API in the `ConnectableView` protocol using an `ActionBinder` object. Use the `map(state:binder:)` method on the protocol as shown below. It provides a value to the text field, and dispatches an action when the text value changes. It also binds a function to a dispatchable action.
+SwiftUI has a focus on two-way bindings that connect to a single value source. To support updates through actions, SwiftDux provides a convenient API in the `ConnectableView` protocol using an `ActionBinder` object. Use the `map(state:binder:)` method on the protocol as shown below. It provides a value to the text field and dispatches an action when the text value changes. It also binds a function to a dispatchable action.
 
 ```swift
 struct LoginForm: View {
@@ -189,6 +172,23 @@ struct LoginForm: View {
     }
   }
 }
+```
+
+## Passing Data to a Connectable View
+In some cases, a connected view needs external information to map the state to its props, such as an identifier. Simply add any needed variables to your view and access them in the mapping function.
+
+```swift
+struct TodoDetailsView: ConnectableView {
+  var id: String
+
+  func map(state: TodoList) -> Todo? {
+    state[id]
+  }
+}
+
+// Somewhere else in the view hierarchy:
+
+TodoDetailsView(id: "123")
 ```
 
 ## Previewing Connected Views
@@ -270,7 +270,7 @@ enum TodoListAction {
 extension TodoListAction {
 
   static func getState(from store: Store<AppState>) -> some Publisher {
-    Just(store.state).merge(with: store.didChange.map { _ in store.state })
+    Just(store.state).merge(with: store.didChange.map { store.state })
   }
 
   static func queryTodos() -> ActionPlan<AppState> {

--- a/Mintfile
+++ b/Mintfile
@@ -1,1 +1,1 @@
-apple/swift-format@master
+apple/swift-format@0.50300.0

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 
 import PackageDescription
 
 let package = Package(
   name: "SwiftDux",
   platforms: [
-    .iOS(.v13),
+    .iOS(.v14),
     .macOS(.v10_15),
   ],
   products: [

--- a/README.md
+++ b/README.md
@@ -195,26 +195,9 @@ struct RootView: View {
 }
 ```
 
-## Passing Data to a Connectable View
-In some cases, a connected view needs external information to map the state to its props, such as an identifier. Simply add any needed variables to your view, and access them in the mapping function.
-
-```swift
-struct TodoDetailsView: ConnectableView {
-  var id: String
-
-  func map(state: TodoList) -> Todo? {
-    state[id]
-  }
-}
-
-// Somewhere else in the view hierarchy:
-
-TodoDetailsView(id: "123")
-```
-
 ## ActionBinding<_>
 
-SwiftUI has a focus on two-way bindings that connect to a single value source. To support updates through actions, SwiftDux provides a convenient API in the `ConnectableView` protocol using an `ActionBinder` object. Use the `map(state:binder:)` method on the protocol as shown below. It provides a value to the text field, and dispatches an action when the text value changes. It also binds a function to a dispatchable action.
+SwiftUI has a focus on two-way bindings that connect to a single value source. To support updates through actions, SwiftDux provides a convenient API in the `ConnectableView` protocol using an `ActionBinder` object. Use the `map(state:binder:)` method on the protocol as shown below. It provides a value to the text field and dispatches an action when the text value changes. It also binds a function to a dispatchable action.
 
 ```swift
 struct LoginForm: View {
@@ -243,6 +226,23 @@ struct LoginForm: View {
     }
   }
 }
+```
+
+## Passing Data to a Connectable View
+In some cases, a connected view needs external information to map the state to its props, such as an identifier. Simply add any needed variables to your view and access them in the mapping function.
+
+```swift
+struct TodoDetailsView: ConnectableView {
+  var id: String
+
+  func map(state: TodoList) -> Todo? {
+    state[id]
+  }
+}
+
+// Somewhere else in the view hierarchy:
+
+TodoDetailsView(id: "123")
 ```
 
 ## Previewing Connected Views
@@ -324,7 +324,7 @@ enum TodoListAction {
 extension TodoListAction {
 
   static func getState(from store: Store<AppState>) -> some Publisher {
-    Just(store.state).merge(with: store.didChange.map { _ in store.state })
+    Just(store.state).merge(with: store.didChange.map { store.state })
   }
 
   static func queryTodos() -> ActionPlan<AppState> {

--- a/Sources/SwiftDux/State/OrderedState.swift
+++ b/Sources/SwiftDux/State/OrderedState.swift
@@ -122,7 +122,7 @@ public struct OrderedState<Substate> where Substate: Identifiable {
   }
 
   /// Create a new `OrderedState` with an ordered array of identifiable substates.
-  /// 
+  ///
   /// - Parameter values: An array of substates. The position of each substate will be used as the initial order.
   @inlinable public init(_ values: [Substate]) {
     var valueByIndex = [Id: Substate](minimumCapacity: values.count)
@@ -382,7 +382,9 @@ extension RangeReplaceableCollection where Self: MutableCollection, Index == Int
       if k != j {
         swapAt(i, j)
         formIndex(after: &i)
-      } else { k = indexes.integerGreaterThan(k) ?? endIndex }
+      } else {
+        k = indexes.integerGreaterThan(k) ?? endIndex
+      }
       formIndex(after: &j)
     }
     removeSubrange(i...)
@@ -403,6 +405,7 @@ extension OrderedState: Decodable where Substate: Decodable {
   /// This allows the `OrderedState<_>` to be decoded from a simple array.
   ///
   /// - Parameter decoder: The decoder.
+  /// - Throws: This function throws an error if the OrderedState could not be decoded.
   public init(from decoder: Decoder) throws {
     var container = try decoder.unkeyedContainer()
     var values = [Substate]()
@@ -425,6 +428,7 @@ extension OrderedState: Encodable where Substate: Encodable {
   /// This allows the `OrderedState<_>` to be encoded as simple array.
   ///
   /// - Parameter encoder: The encoder.
+  /// - Throws: This function throws an error if the OrderedState could not be encoded.
   @inlinable public func encode(to encoder: Encoder) throws {
     var container = encoder.unkeyedContainer()
     try container.encode(contentsOf: values)

--- a/Sources/SwiftDux/Store/StoreProxy.swift
+++ b/Sources/SwiftDux/Store/StoreProxy.swift
@@ -13,7 +13,7 @@ public struct StoreProxy<State>: ActionDispatcher {
   internal var getState: () -> State
 
   /// Emits after the specified action was sent to the store.
-  public var didChange: AnyPublisher<Action, Never>
+  public var didChange: StorePublisher
 
   /// Send an action to the next middleware
   @usableFromInline
@@ -33,7 +33,7 @@ public struct StoreProxy<State>: ActionDispatcher {
 
   @inlinable internal init(
     getState: @escaping () -> State,
-    didChange: AnyPublisher<Action, Never>,
+    didChange: StorePublisher,
     dispatcher: ActionDispatcher,
     next: SendAction? = nil,
     done: (() -> Void)? = nil

--- a/Sources/SwiftDux/Store/StorePublisher.swift
+++ b/Sources/SwiftDux/Store/StorePublisher.swift
@@ -1,0 +1,17 @@
+import Combine
+import Foundation
+
+/// Publishes state changes from the store.
+public final class StorePublisher: Publisher {
+  public typealias Failure = Never
+  public typealias Output = Void
+  private let subject = PassthroughSubject<Void, Never>()
+
+  public func receive<S>(subscriber: S) where S: Subscriber, S.Failure == Never, S.Input == Void {
+    subject.receive(subscriber: subscriber)
+  }
+
+  internal func send() {
+    subject.send()
+  }
+}

--- a/Sources/SwiftDux/Store/StoreReducer.swift
+++ b/Sources/SwiftDux/Store/StoreReducer.swift
@@ -14,11 +14,11 @@ public enum StoreAction<State>: Action {
 
 internal final class StoreReducer<State, RootReducer>: Reducer where RootReducer: Reducer, RootReducer.State == State {
   private let rootReducer: RootReducer
-  
+
   init(rootReducer: RootReducer) {
     self.rootReducer = rootReducer
   }
-  
+
   @inlinable public func reduce(state: State, action: StoreAction<State>) -> State {
     switch action {
     case .reset(let newState):
@@ -27,7 +27,7 @@ internal final class StoreReducer<State, RootReducer>: Reducer where RootReducer
       return state
     }
   }
-  
+
   @inlinable public func reduceNext(state: State, action: Action) -> State {
     rootReducer.reduceAny(state: state, action: action)
   }

--- a/Sources/SwiftDux/Store/StoreReducer.swift
+++ b/Sources/SwiftDux/Store/StoreReducer.swift
@@ -12,8 +12,13 @@ public enum StoreAction<State>: Action {
   case reset(state: State)
 }
 
-internal final class StoreReducer<State>: Reducer {
-
+internal final class StoreReducer<State, RootReducer>: Reducer where RootReducer: Reducer, RootReducer.State == State {
+  private let rootReducer: RootReducer
+  
+  init(rootReducer: RootReducer) {
+    self.rootReducer = rootReducer
+  }
+  
   @inlinable public func reduce(state: State, action: StoreAction<State>) -> State {
     switch action {
     case .reset(let newState):
@@ -21,5 +26,9 @@ internal final class StoreReducer<State>: Reducer {
     default:
       return state
     }
+  }
+  
+  @inlinable public func reduceNext(state: State, action: Action) -> State {
+    rootReducer.reduceAny(state: state, action: action)
   }
 }

--- a/Sources/SwiftDux/UI/ActionBinder.swift
+++ b/Sources/SwiftDux/UI/ActionBinder.swift
@@ -102,6 +102,3 @@ public struct ActionBinder {
     actionDispatcher.send(action)
   }
 }
-
-@available(*, deprecated, renamed: "ActionBinder")
-public typealias StateBinder = ActionBinder

--- a/Sources/SwiftDux/UI/Connectable.swift
+++ b/Sources/SwiftDux/UI/Connectable.swift
@@ -9,12 +9,6 @@ public protocol Connectable {
   associatedtype Superstate
   associatedtype Props: Equatable
 
-  /// Causes the view to be updated based on a dispatched action.
-  ///
-  /// - Parameter action: The dispatched action
-  /// - Returns: True if the view should update.
-  func updateWhen(action: Action) -> Bool
-
   /// Map a superstate to the state needed by the view using the provided parameter.
   ///
   /// The method can return nil until the state becomes available. While it is nil, the view
@@ -35,13 +29,6 @@ public protocol Connectable {
 }
 
 extension Connectable {
-
-  /// Default implementation disables updates by action.
-  public func updateWhen(action: Action) -> Bool {
-    guard let action = action as? NoUpdateAction else { return false }
-    action.unused = true
-    return true
-  }
 
   /// Default implementation. Returns nil.
   @inlinable public func map(state: Superstate) -> Props? {

--- a/Sources/SwiftDux/UI/ConnectableView.swift
+++ b/Sources/SwiftDux/UI/ConnectableView.swift
@@ -19,7 +19,6 @@ extension ConnectableView {
       content: { props in
         self.body(props: props)
       },
-      filter: updateWhen,
       mapProps: map
     )
   }

--- a/Sources/SwiftDux/UI/Connector.swift
+++ b/Sources/SwiftDux/UI/Connector.swift
@@ -1,20 +1,11 @@
 import Combine
 import SwiftUI
 
-/// Indicates a connectable view should not update when the state changes. The view will not subscribe to the store, and instead update
-/// only when it dispatches an action.
-internal final class NoUpdateAction: Action {
-  var unused: Bool = false
-}
-
-fileprivate let noUpdateAction = NoUpdateAction()
-
 public struct Connector<Content, Superstate, Props>: View where Props: Equatable, Content: View {
   @Environment(\.store) private var anyStore
   @Environment(\.actionDispatcher) private var actionDispatcher
 
   private var content: (Props) -> Content
-  private var filter: ((Action) -> Bool)?
   private var mapProps: (Superstate, ActionBinder) -> Props?
 
   private var store: StoreProxy<Superstate>? {
@@ -28,47 +19,37 @@ public struct Connector<Content, Superstate, Props>: View where Props: Equatable
 
   public init(
     content: @escaping (Props) -> Content,
-    filter: ((Action) -> Bool)?,
     mapProps: @escaping (Superstate, ActionBinder) -> Props?
   ) {
     self.content = content
-    self.filter = filter
     self.mapProps = mapProps
   }
 
   public var body: some View {
-    createPropsPublisher().map { ConnectorInner(content: content, initialProps: getProps(), propsPublisher: $0) }
-  }
-
-  private func createPropsPublisher() -> AnyPublisher<Props, Never>? {
-    createFilteredPublisher()?.compactMap { _ in self.getProps() }
-      .removeDuplicates()
-      .eraseToAnyPublisher()
-  }
-
-  private func createFilteredPublisher() -> AnyPublisher<Action, Never>? {
-    guard let filter = filter, hasUpdateFilter() else {
-      return store?.didChange
+    store.map { store in
+      ConnectorInner(
+        content: content,
+        initialProps: getProps(),
+        propsPublisher: store.didChange
+          .compactMap { _ in getProps() }
+          .removeDuplicates()
+      )
     }
-    return store?.didChange.filter(filter).eraseToAnyPublisher()
   }
 
   private func getProps() -> Props? {
-    store.flatMap { mapProps($0.state, ActionBinder(actionDispatcher: self.actionDispatcher)) }
-  }
-
-  private func hasUpdateFilter() -> Bool {
-    _ = filter?(noUpdateAction)
-    return !noUpdateAction.unused
+    guard let store = store else { return nil }
+    return mapProps(store.state, ActionBinder(actionDispatcher: self.actionDispatcher))
   }
 }
 
-internal struct ConnectorInner<Content, Props>: View where Props: Equatable, Content: View {
+internal struct ConnectorInner<Props, PropsPublisher, Content>: View
+where Props: Equatable, PropsPublisher: Publisher, PropsPublisher.Output == Props, PropsPublisher.Failure == Never, Content: View {
   private var content: (Props) -> Content
-  private var propsPublisher: AnyPublisher<Props, Never>
+  private var propsPublisher: PropsPublisher
   @State private var props: Props?
 
-  internal init(content: @escaping (Props) -> Content, initialProps: Props?, propsPublisher: AnyPublisher<Props, Never>) {
+  internal init(content: @escaping (Props) -> Content, initialProps: Props?, propsPublisher: PropsPublisher) {
     self.content = content
     self.propsPublisher = propsPublisher
     self._props = State(initialValue: initialProps)

--- a/Sources/SwiftDux/UI/ViewModifiers/OnActionViewModifier.swift
+++ b/Sources/SwiftDux/UI/ViewModifiers/OnActionViewModifier.swift
@@ -33,7 +33,6 @@ extension OnActionViewModifier {
       nextDispatcher.send(action)
     }
   }
-
 }
 
 extension View {

--- a/Sources/SwiftDuxExtras/Persistence/JSONStatePersistor.swift
+++ b/Sources/SwiftDuxExtras/Persistence/JSONStatePersistor.swift
@@ -29,6 +29,7 @@ public final class JSONStatePersistor<State>: StatePersistor where State: Codabl
   ///
   /// - Parameter state: The state
   /// - Returns: The encoded state
+  /// - Throws: This function throws an error if the state could not be encoded.
   public func encode(state: State) throws -> Data {
     try encoder.encode(state)
   }
@@ -37,6 +38,7 @@ public final class JSONStatePersistor<State>: StatePersistor where State: Codabl
   ///
   /// - Parameter data: The json data
   /// - Returns: The decoded state
+  /// - Throws: This function throws an error if the state could not be decoded.
   public func decode(data: Data) throws -> State {
     try decoder.decode(State.self, from: data)
   }

--- a/Sources/SwiftDuxExtras/Persistence/StatePersistor.swift
+++ b/Sources/SwiftDuxExtras/Persistence/StatePersistor.swift
@@ -18,14 +18,16 @@ public protocol StatePersistor {
 
   /// Encodes the state into a raw data object.
   ///
-  ///  - Parameter state: The state to encode
+  /// - Parameter state: The state to encode
   /// - Returns: The encoded state.
+  /// - Throws: This function throws an error if the state could not be encoded.
   func encode(state: State) throws -> Data
 
   /// Decode raw data into a new state object.
   ///
   /// - Parameter data: The data to decode.
   /// - Returns: The decoded state
+  /// - Throws: This function throws an error if the state could not be decoded.
   func decode(data: Data) throws -> State
 
 }

--- a/Sources/SwiftDuxExtras/Persistence/StatePersistor.swift
+++ b/Sources/SwiftDuxExtras/Persistence/StatePersistor.swift
@@ -76,9 +76,8 @@ extension StatePersistor {
     debounceFor interval: RunLoop.SchedulerTimeType.Stride = .seconds(1)
   ) -> AnyCancellable {
     store.didChange
-      .filter { !($0 is StoreAction<State>) }
       .debounce(for: interval, scheduler: RunLoop.main)
-      .compactMap { [weak store] (action: Action) in store?.state }
+      .compactMap { [weak store] in store?.state }
       .persist(with: self)
   }
 
@@ -93,7 +92,6 @@ extension StatePersistor {
     debounceFor interval: RunLoop.SchedulerTimeType.Stride = .seconds(1)
   ) -> AnyCancellable {
     store.didChange
-      .filter { !($0 is StoreAction<State>) }
       .debounce(for: interval, scheduler: RunLoop.main)
       .compactMap { _ in store.state }
       .persist(with: self)


### PR DESCRIPTION
This PR removes what's left of the original action-based update implementation used during the beta period of SwiftUI. It also replaces the AnyPublisher type with a dedicated StorePublisher type. In testing, these changes provides a small boost in performance and reduce the overall complexity of the library.

# Work Performed
- Removed ActionType from the Store<_>'s didChange publisher.
- Updated StatePersistor so it no longer relies on the dispatched action.
- Removed StateBinder.
- Added a new StorePublisher type to replace AnyPublisher<_, _>.