### PR TITLE
Refactored Action Chaining

### DIFF
--- a/Guides/Getting Started.md
+++ b/Guides/Getting Started.md
@@ -154,21 +154,12 @@ let plan = ActionPlan<AppState> { store in
   store.send(actionB)
 }
 
-/// Perform async operations:
+/// Subscribe to services and return a publisher that sends actions to the store.
 
 let plan = ActionPlan<AppState> { store in
-  userLocationService.getLocation { location in
-    store.send(LocationAction.updateLocation(location))
-  }
-}
-
-/// Subscribe to services and publish new actions to the store.
-
-let plan = ActionPlan<AppState> { store, completed in
   userLocationService
-    .subscribeToUpdates()
+    .publisher
     .map { LocationAction.updateLocation($0) }
-    .send(to: store, receivedCompletion: completed)
 }
 
 /// In a View, dispatch the plan like any other action:

--- a/Guides/Getting Started.md
+++ b/Guides/Getting Started.md
@@ -20,11 +20,13 @@ Below is an example of a todo app's state. It has a root `AppState` as well as a
 ```swift
 import SwiftDux
 
-struct AppState: Equatable {
+typealias StateType = Equatable & Codable
+
+struct AppState: StateType {
   todos: OrderedState<TodoItem>
 }
 
-struct TodoItem: Equatable, Identifiable {
+struct TodoItem: StateType, Identifiable {
   var id: String,
   var text: String
 }
@@ -51,26 +53,20 @@ A reducer consumes an action to produce a new state.
 ```swift
 final class TodosReducer: Reducer {
 
-  func reduce(state: OrderedState<TodoItem>, action: TodoAction) -> OrderedState<TodoItem> {
+  func reduce(state: AppState, action: TodoAction) -> AppState {
     var state = state
     switch action {
     case .addTodo(let text):
       let id = UUID().uuidString
-      state.append(TodoItemState(id: id, text: text))
+      state.todos.append(TodoItemState(id: id, text: text))
     case .removeTodos(let indexSet):
-      state.remove(at: indexSet)
+      state.todos.remove(at: indexSet)
     case .moveTodos(let indexSet, let index):
-      state.move(from: indexSet, to: index)
+      state.todos.move(from: indexSet, to: index)
     }
     return state
   }
 }
-```
-
-Reducers can also be added together to form a composite reducer.
-
-```swift
-let combinedReducer = AppReducer + NavigationReducer
 ```
 
 ## Store
@@ -80,16 +76,56 @@ The store manages the state and notifies the views of any updates.
 ```swift
 import SwiftDux
 
-let store = Store(AppState(todos: OrderedState()), AppReducer())
+let store = Store(
+  state: AppState(todos: OrderedState()),
+  reducer: AppReducer()
+)
 
 window.rootViewController = UIHostingController(
   rootView: RootView().provideStore(store)
 )
 ```
 
+## Middleware
+SwiftDux supports middleware to expand its functionality. The SwiftDuxExtras module provides two built-in middleware to get started:
+
+- `PersistStateMiddleware` Persists and restores the application state between sessions.
+- `PrintActionMiddleware` prints out each dispatched action for debugging purposes.
+
+```swift
+import SwiftDux
+
+let store = Store(
+  state: AppState(todos: OrderedState()),
+  reducer: AppReducer(),
+  middleware: PrintActionMiddleware())
+)
+
+window.rootViewController = UIHostingController(
+  rootView: RootView().provideStore(store)
+)
+```
+
+## Composing Reducers, Actions, and Middleware
+You may compose a set of reducers, actions, or middleware into an ordered chain using the '+' operator.
+
+```swift
+// Break up an application into smaller modules by composing reducers.
+let rootReducer = AppReducer() + NavigationReducer()
+
+// Add multiple middleware together.
+let middleware = PrintActionMiddleware() + PersistStateMiddleware(JSONStatePersistor()
+
+let store = Store(
+  state: AppState(todos: OrderedState()),
+  reducer: reducer,
+  middleware: middleware
+)
+```
+
 ## ConnectableView
 
-The `ConnectableView` protocol provides a slice of the application state to your views using the functions `map(state:)` or  `map(state:binder:)`.
+The `ConnectableView` protocol provides a slice of the application state to your views using the functions `map(state:)` or  `map(state:binder:)`. It automatically updates the view when the props value has changed.
 
 ```swift
 struct TodosView: ConnectableView {
@@ -113,8 +149,7 @@ struct TodosView: ConnectableView {
 
 ## ActionBinding<_>
 
-Using the `map(state:binder:)` method on the `ConnectableView` protocol to bind an action to the props object. It can also be used to bind an updatable state value
-with an action.
+Use the `map(state:binder:)` method on the `ConnectableView` protocol to bind an action to the props object. It can also be used to bind an updatable state value with an action.
 
 ```swift
 struct TodosView: ConnectableView {
@@ -142,13 +177,15 @@ struct TodosView: ConnectableView {
   }
 }
 ```
+
 ## Action Plans
-An `ActionPlan` is a special kind of action that can be used to group other actions together or perform any kind of async logic outside of a reducer.
+An `ActionPlan` is a special kind of action that can be used to group other actions together or perform any kind of async logic outside of a reducer. It's also useful for actions that may require information about the state before it can be dispatched.
 
 ```swift
-/// Dispatch multiple actions together synchronously:
+/// Dispatch multiple actions after checking the current state of the application:
 
 let plan = ActionPlan<AppState> { store in
+  guard store.state.someValue == nil else { return }
   store.send(actionA)
   store.send(actionB)
   store.send(actionB)
@@ -159,12 +196,44 @@ let plan = ActionPlan<AppState> { store in
 let plan = ActionPlan<AppState> { store in
   userLocationService
     .publisher
-    .map { LocationAction.updateLocation($0) }
+    .map { LocationAction.updateUserLocation($0) }
 }
+```
 
-/// In a View, dispatch the plan like any other action:
+## Action Dispatching
+You can access the `ActionDispatcher` of the store through the environment values. This allows you to dispatch actions from any view.
 
-dispatch(plan)
+```swift
+struct MyView: View {
+  @Environment(\.actionDispatcher) private var dispatch
+
+  var body: some View {
+    MyForm.onAppear { dispatch(FormAction.prepare) }
+  }
+}
+```
+
+If it's an ActionPlan that's meant to be kept alive through a publisher, then you'll want to send it as a cancellable.
+
+```swift
+struct MyView: View {
+  @Environment(\.actionDispatcher) private var dispatch
+  @State private var cancellable: Cancellable? = nil
+
+  var body: some View {
+    MyForm.onAppear { cancellable = dispatch.sendAsCancellable(SecurityAction.whileAccessTokenIsValid) }
+  }
+}
+```
+
+The above can be further simplified by using the built-in `onAppear(dispatch:)` method instead. This method not only dispatches regular actions, but it automatically handles cancellable ones as well.
+
+```swift
+struct MyView: View {
+  var body: some View {
+    MyForm.onAppear(dispatch: SecurityAction.whileAccessTokenIsValid)
+  }
+}
 ```
 
 ## Previewing Connected Views

--- a/README.md
+++ b/README.md
@@ -212,13 +212,12 @@ let plan = ActionPlan<AppState> { store in
   }
 }
 
-/// Subscribe to services and publish new actions to the store.
+/// Subscribe to services and return a publisher that sends actions to the store.
 
-let plan = ActionPlan<AppState> { store, completed in
+let plan = ActionPlan<AppState> { store in
   userLocationService
-    .subscribeToUpdates()
+    .publisher
     .map { LocationAction.updateLocation($0) }
-    .send(to: store, receivedCompletion: completed)
 }
 
 /// In a View, dispatch the plan like any other action:

--- a/Sources/SwiftDux/Action/Action.swift
+++ b/Sources/SwiftDux/Action/Action.swift
@@ -1,11 +1,7 @@
 import Combine
 import Foundation
 
-/// A dispatchable action that provides information to a reducer to mutate the state of the application.
-///
-/// Typically this is done with enum types, however,  it could be added to protocols or structs if
-/// a more complex solution is needed. Structs are also a could choice if actions need to be codable.
-///
+/// A dispatchable action sent to a `Store<_>` to modify the state.
 /// ```
 ///   enum TodoList : Action {
 ///     case setItems(items: [TodoItem])
@@ -13,36 +9,42 @@ import Foundation
 ///     case removeItems(at: IndexSet)
 ///     case moveItems(at: IndexSet, to: Int)
 ///   }
-///
-///   // You can also create new protocols that represent an entire feature's actions.
-///   // This can allows views to update off of a granular action or any actions
-///   // of a given feature.
-///   protocol FeatureLevelAction : Action {}
-///
-///   enum SubfeatureAction: FeatureLevelAction {
-///     ...
-///   }
 /// ```
 public protocol Action {}
 
-/// A special kind of action that performs internal logic outside of a reducer.
-///
-/// An ActionPlan<_> is a concrete type of RunnbableAction, and is good enough
-/// for most cases.
-public protocol RunnableAction: Action {
+extension Action {
 
-  /// When the action is dispatched to a store, this method will be called to handle
-  /// any logic by the action.
+  /// Chains an array of actions to be dispatched next.
   ///
-  /// - Parameter store: The store that the action has been dispatched to.
-  /// - Returns: An optional cancellable.
-  func run<T>(store: Store<T>) -> AnyCancellable?
+  /// - Parameter actions: An array of actions to chain together.
+  /// - Returns: A composite action.
+  @inlinable public func then(_ actions: [Action]) -> CompositeAction {
+    CompositeAction([self] + actions)
+  }
 
-  /// Send an action that can be cancelled.
+  /// Chains an array of actions to be dispatched next.
   ///
-  /// - Parameter dispatcher: The send function that dispatches an action.
-  /// - Returns: AnyCancellable to cancel the action plan.
-  func sendAsCancellable(_ dispatcher: ActionDispatcher) -> AnyCancellable
+  /// - Parameter actions: One or more actions to chain together.
+  /// - Returns: A composite action.
+  @inlinable public func then(_ actions: Action...) -> CompositeAction {
+    then(actions)
+  }
+
+  /// Call the provided block next.
+  ///
+  /// - Parameter block: A block of code to execute once the previous action has completed.
+  /// - Returns: A composite action.
+  @inlinable public func then(_ block: @escaping () -> Void) -> CompositeAction {
+    then(ActionPlan<Any> { _ in block() })
+  }
+}
+
+@inlinable public func + (lhs: Action, rhs: Action) -> CompositeAction {
+  if var lhs = lhs as? CompositeAction {
+    lhs.actions.append(rhs)
+    return lhs
+  }
+  return CompositeAction([lhs, rhs])
 }
 
 /// A noop action used by reducers that may not have their own actions.
@@ -53,5 +55,5 @@ public struct EmptyAction: Action {
 
 /// A closure that dispatches an action.
 ///
-/// - Parameter action: Dispatches the given action synchronously.
+/// - Parameter action: The action to dispatch.
 public typealias SendAction = (Action) -> Void

--- a/Sources/SwiftDux/Action/ActionDispatcher.swift
+++ b/Sources/SwiftDux/Action/ActionDispatcher.swift
@@ -11,6 +11,12 @@ public protocol ActionDispatcher {
   ///
   /// - Parameter action: An action to dispatch to the store.
   func send(_ action: Action)
+
+  /// Sends a cancellable action to mutate the application state.
+  ///
+  /// - Parameter action: An action to dispatch to the store.
+  /// - Returns: A cancellable object.
+  func sendAsCancellable(_ action: Action) -> Cancellable
 }
 
 extension ActionDispatcher {
@@ -20,13 +26,5 @@ extension ActionDispatcher {
   /// - Parameter action: An action to dispatch to the store
   @inlinable public func callAsFunction(_ action: Action) {
     send(action)
-  }
-
-  /// Send an action plan that returns a cancellable object.
-  ///
-  /// - Parameter actionPlan: The action
-  /// - Returns: A cancellable to cancel the action.
-  @inlinable public func sendAsCancellable<T>(_ actionPlan: ActionPlan<T>) -> AnyCancellable {
-    actionPlan.sendAsCancellable(self)
   }
 }

--- a/Sources/SwiftDux/Action/ActionPlan.swift
+++ b/Sources/SwiftDux/Action/ActionPlan.swift
@@ -1,13 +1,13 @@
 import Combine
 import Foundation
 
-/// Encapsulates multiple actions into a packaged up "action plan"
+/// Encapsulates external business logic outside of a reducer into a special kind of action.
 ///
 ///```
 ///   enum UserAction {
 ///
 ///     static func loadUser(byId id: String) -> ActionPlan<AppState> {
-///       ActionPlan<AppState> { store, completed in
+///       ActionPlan<AppState> { store in
 ///         guard !store.state.users.hasValue(id) else { return nil }
 ///         store.send(UserAction.setLoading(true))
 ///         return UserService.getUser(id)
@@ -19,170 +19,64 @@ import Foundation
 ///               ].publisher
 ///             }
 ///           }
-///           .send(to: store, receivedCompletion: completed)
 ///       }
 ///     }
-///
 ///   }
 ///
-///   // Somewhere inside a view:
+///   // Inside a view:
 ///
-///   func loadUser() {
-///     dispatch(UserAction.loadUser(byId: self.id))
+///   func body(props: Props) -> some View {
+///     UserInfo(user: props.user)
+///       .onAppear { dispatch(UserAction.loadUser(byId: self.id)) }
 ///   }
 ///```.
 public struct ActionPlan<State>: RunnableAction {
 
-  /// The body of a publishable action plan.
-  ///
-  /// - Parameter StoreProxy: Dispatch actions or retreive the current state from the store.
-  /// - Returns: A publisher that can send actions to the store.
-  public typealias Body = (StoreProxy<State>, @escaping ActionSubscriber.ReceivedCompletion) -> AnyCancellable?
+  @usableFromInline internal typealias Body = (StoreProxy<State>) -> AnyPublisher<Action, Never>
 
   @usableFromInline
   internal var body: Body
 
-  @usableFromInline
-  internal var nextActions: [ActionPlan<State>] = []
-
-  /// Create a new action plan that returns an optional publisher.
-  ///
-  /// - Parameter body: The body of the action plan.
-  @inlinable public init(_ body: @escaping Body) {
-    self.body = body
-  }
-
-  /// Create a new action plan that returns an optional publisher.
+  /// Create an action plan that returns a publisher.
   ///
   /// - Parameter body: The body of the action plan.
   @inlinable public init<P>(_ body: @escaping (StoreProxy<State>) -> P) where P: Publisher, P.Output == Action, P.Failure == Never {
-    self.body = { store, completed in
-      body(store).send(to: store, receivedCompletion: completed)
-    }
+    self.body = { store in body(store).eraseToAnyPublisher() }
   }
 
-  /// Create a new action plan.
+  /// Create a synchronous action plan. The plan expects to be completed once the body has returned.
   ///
   /// - Parameter body: The body of the action plan.
   @inlinable public init(_ body: @escaping (StoreProxy<State>) -> Void) {
-    self.body = { store, completed in
+    self.body = { store in
       body(store)
-      completed()
-      return nil
+      return Empty().eraseToAnyPublisher()
     }
   }
 
-  public func run<T>(store: Store<T>) -> AnyCancellable? {
-    var cancellable: AnyCancellable? = nil
-    let done = {
-      cancellable?.cancel()
-      cancellable = nil
-    }
-    guard let proxy = store.proxy(for: State.self, done: done) else { return nil }
-    cancellable = run(proxy) { [proxy] in
-      proxy.done()
-    }
-    return cancellable
-  }
-
-  /// Manually run the action plan.
+  /// Create an asynchronous action plan that returns a cancellable.
   ///
-  /// this can be useful to run an action plan inside a containing action plan.
-  /// - Parameters
-  ///   - store: Dispatch actions or retreive the current state from the store.
-  ///   - completed: A block that's called when the plan has completed.
-  /// - Returns: A publisher that can send actions to the store.
-  @inlinable public func run(_ store: StoreProxy<State>, completed: @escaping ActionSubscriber.ReceivedCompletion = {}) -> AnyCancellable? {
-    guard var nextAction = nextActions.first else {
-      return body(store, completed)
-    }
-
-    nextAction.nextActions = Array(nextActions[1...])
-
-    return body(store) {
-      completed()
-      store.send(nextAction)
-    }
-  }
-
-  /// Send an action plan that can be cancelled.
-  ///
-  /// This is useful for action plans that return a publisher that require a cancellable step. For example, a web request
-  /// that should be cancelled if the user navigates away from the relevant view.
-  ///
-  /// ```
-  /// struct MyView: View {
-  ///
-  ///   @MappedDispatch() private var dispatch
-  ///
-  ///   @State private var username: String = ""
-  ///   @State private var password: String = ""
-  ///
-  ///   @State private var signUpCancellable: AnyCancellable? = nil
-  ///
-  ///   var body: some View {
-  ///     Group {
-  ///       /// ...signup form
-  ///       Button(action: self.signUp) { Text("Sign Up") }
-  ///     }
-  ///     .onDisappear { self.signUpCancellable?.cancel() }
-  ///   }
-  ///
-  ///   func signUp() {
-  ///     signUpCancellable = signUpActionPlan(username: username, password: password).sendAsCancellable(dispatch)
-  ///   }
-  /// }
-  /// ```
-  ///
-  /// - Parameter dispatcher: The send function that dispatches an action.
-  /// - Returns: AnyCancellable to cancel the action plan.
-  @inlinable public func sendAsCancellable(_ dispatcher: ActionDispatcher) -> AnyCancellable {
-    var publisherCancellable: AnyCancellable? = nil
-    dispatcher(
-      ActionPlan<State> { store, completed in
-        publisherCancellable = self.run(store) {
-          publisherCancellable = nil
-          completed()
+  /// - Parameter body: The body of the action plan.
+  @inlinable public init(_ body: @escaping (StoreProxy<State>, @escaping () -> Void) -> Cancellable) {
+    self.body = { store in
+      var cancellable: Cancellable? = nil
+      return Deferred {
+        Future<Void, Never> { promise in
+          cancellable = body(store) {
+            promise(.success(()))
+          }
         }
-        return publisherCancellable
+        .compactMap { _ -> Action? in nil }
       }
-    )
-    return AnyCancellable { [publisherCancellable] in publisherCancellable?.cancel() }
+      .handleEvents(receiveCancel: { cancellable?.cancel() })
+      .eraseToAnyPublisher()
+    }
   }
 
-  /// Dispatches another action plan after this one has completed. This allows
-  /// action plans to be chained together to perform their actions synchronously.
-  ///
-  /// - Parameter actionPlans: One or mroe action plans to chain after this one.
-  /// - Returns: A new action plan that chains the source plan with the provided ones in the parameters.
-  @inlinable public func then(_ actionPlans: ActionPlan<State>...) -> ActionPlan<State> {
-    var copy = self
-    copy.nextActions.append(contentsOf: actionPlans)
-    return copy
-  }
-
-  /// Calls the provided block once the action plan has completed. The current state is
-  /// provided to the block.
-  ///
-  /// - Parameter block: A block of code to execute once the action plan has completed.
-  /// - Returns: A new action plan.
-  @inlinable public func then(_ block: @escaping (State) -> Void) -> ActionPlan<State> {
-    then(
-      ActionPlan<State> { store in
-        block(store.state)
-      }
-    )
-  }
-
-  /// Calls the provided block once the action plan has completed.
-  ///
-  /// - Parameter block: A block of code to execute once the action plan has completed.
-  /// - Returns: A new action plan.
-  @inlinable public func then(_ block: @escaping () -> Void) -> ActionPlan<State> {
-    then(
-      ActionPlan<State> { _ in
-        block()
-      }
-    )
+  @inlinable public func run<T>(store: Store<T>) -> AnyPublisher<Action, Never> {
+    guard let storeProxy = store.proxy(for: State.self) else {
+      fatalError("Store does not support type `\(State.self)` from ActionPlan.")
+    }
+    return body(storeProxy)
   }
 }

--- a/Sources/SwiftDux/Action/ActionSubscriber.swift
+++ b/Sources/SwiftDux/Action/ActionSubscriber.swift
@@ -2,9 +2,9 @@ import Combine
 import Foundation
 
 /// Subscribes to a publisher of actions, and sends them to an action dispatcher.
-final public class ActionSubscriber: Subscriber {
+final internal class ActionSubscriber: Subscriber {
 
-  public typealias ReceivedCompletion = () -> Void
+  typealias ReceivedCompletion = () -> Void
 
   private let actionDispatcher: ActionDispatcher
   private let receivedCompletion: ReceivedCompletion?
@@ -44,11 +44,12 @@ final public class ActionSubscriber: Subscriber {
 extension Publisher where Output == Action, Failure == Never {
 
   /// Subscribe to a publisher of actions, and send the results to an action dispatcher.
+  ///
   /// - Parameters:
   ///   - actionDispatcher: The ActionDispatcher
   ///   - receivedCompletion: An optional block called when the publisher completes.
   /// - Returns: A cancellable to unsubscribe.
-  public func send(to actionDispatcher: ActionDispatcher, receivedCompletion: ActionSubscriber.ReceivedCompletion? = nil) -> AnyCancellable {
+  public func send(to actionDispatcher: ActionDispatcher, receivedCompletion: (() -> Void)? = nil) -> AnyCancellable {
     let subscriber = ActionSubscriber(
       actionDispatcher: actionDispatcher,
       receivedCompletion: receivedCompletion

--- a/Sources/SwiftDux/Action/CompositeAction.swift
+++ b/Sources/SwiftDux/Action/CompositeAction.swift
@@ -1,0 +1,58 @@
+import Combine
+import Foundation
+
+/// Combines multiple actions into a chained, composite action. It guarantees the dispatch order of each action.
+public struct CompositeAction: RunnableAction {
+
+  @usableFromInline
+  internal var actions: [Action] = []
+
+  /// Create a composite action.
+  ///
+  /// - Parameter actions: An array of actions to chain.
+  @usableFromInline internal init(_ actions: [Action] = []) {
+    self.actions = actions
+  }
+
+  public func run<T>(store: Store<T>) -> AnyPublisher<Action, Never> {
+    actions
+      .publisher
+      .flatMap(maxPublishers: .max(1)) { action in
+        self.run(action: action, forStore: store)
+      }
+      .eraseToAnyPublisher()
+  }
+
+  private func run<T>(action: Action, forStore store: Store<T>) -> AnyPublisher<Action, Never> {
+    if let action = action as? RunnableAction {
+      return action.run(store: store)
+    }
+    return Just(action).eraseToAnyPublisher()
+  }
+
+  /// Chains an array of actions to be dispatched next.
+  ///
+  /// - Parameter actions: An array of actions to chain together.
+  /// - Returns: A composite action.
+  @inlinable public func then(_ actions: [Action]) -> CompositeAction {
+    var nextAction = self
+    nextAction.actions += actions
+    return nextAction
+  }
+
+  /// Chains an array of actions to be dispatched next.
+  ///
+  /// - Parameter actions: One or more actions to chain together.
+  /// - Returns: A composite action.
+  @inlinable public func then(_ actions: Action...) -> CompositeAction {
+    then(actions)
+  }
+
+  /// Call the provided block next.
+  ///
+  /// - Parameter block: A block of code to execute once the previous action has completed.
+  /// - Returns: A composite action.
+  @inlinable public func then(_ block: @escaping () -> Void) -> CompositeAction {
+    then(ActionPlan<Any> { _ in block() })
+  }
+}

--- a/Sources/SwiftDux/Action/RunnableAction.swift
+++ b/Sources/SwiftDux/Action/RunnableAction.swift
@@ -1,0 +1,13 @@
+import Combine
+import Foundation
+
+/// An action that performs external logic outside of a reducer.
+public protocol RunnableAction: Action {
+
+  /// When the action is dispatched to a store, this method will be called to handle
+  /// any logic by the action.
+  ///
+  /// - Parameter store: The store that the action has been dispatched to.
+  /// - Returns: A cancellable object.
+  func run<T>(store: Store<T>) -> AnyPublisher<Action, Never>
+}

--- a/Sources/SwiftDux/Middleware/CompositeMiddleware.swift
+++ b/Sources/SwiftDux/Middleware/CompositeMiddleware.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-/// Combines two middleware together.
-public struct CombinedMiddleware<State, A, B>: Middleware where A: Middleware, B: Middleware, A.State == State, B.State == State {
+/// Use the '+' operator to combine two or more middleware together.
+public struct CompositeMiddleware<State, A, B>: Middleware where A: Middleware, B: Middleware, A.State == State, B.State == State {
   private var previousMiddleware: A
   private var nextMiddleware: B
 
-  internal init(previousMiddleware: A, nextMiddleware: B) {
+  @usableFromInline internal init(previousMiddleware: A, nextMiddleware: B) {
     self.previousMiddleware = previousMiddleware
     self.nextMiddleware = nextMiddleware
   }

--- a/Sources/SwiftDux/Middleware/Middleware.swift
+++ b/Sources/SwiftDux/Middleware/Middleware.swift
@@ -39,16 +39,16 @@ extension Middleware {
   @inlinable public func compile(store: StoreProxy<State>) -> SendAction {
     { action in self.run(store: store, action: action) }
   }
+}
 
-  /// Compose two middleware together.
-  /// - Parameters:
-  ///   - previousMiddleware: The  middleware to be called first.
-  ///   - nextMiddleware: The next middleware to call.
-  /// - Returns: The combined middleware.
-  public static func + <M>(previousMiddleware: Self, _ nextMiddleware: M) -> CombinedMiddleware<State, Self, M>
-  where M: Middleware, M.State == State {
-    CombinedMiddleware(previousMiddleware: previousMiddleware, nextMiddleware: nextMiddleware)
-  }
+/// Compose two middleware together.
+/// - Parameters:
+///   - previousMiddleware: The  middleware to be called first.
+///   - nextMiddleware: The next middleware to call.
+/// - Returns: The combined middleware.
+@inlinable public func + <M1, M2>(previousMiddleware: M1, _ nextMiddleware: M2) -> CompositeMiddleware<M1.State, M1, M2>
+where M1: Middleware, M2: Middleware, M1.State == M2.State {
+  CompositeMiddleware(previousMiddleware: previousMiddleware, nextMiddleware: nextMiddleware)
 }
 
 internal final class NoopMiddleware<State>: Middleware {

--- a/Sources/SwiftDux/Reducer/CompositeReducer.swift
+++ b/Sources/SwiftDux/Reducer/CompositeReducer.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-/// Combines two reducers together. Use the `+` operator to create a combned reducer.
-public final class CombinedReducer<State, A, B>: Reducer where A: Reducer, B: Reducer, A.State == State, B.State == State {
+/// Use the '+' operator to combine two or more reducers together.
+public final class CompositeReducer<State, A, B>: Reducer where A: Reducer, B: Reducer, A.State == State, B.State == State {
   @usableFromInline
   internal var previousReducer: A
 
   @usableFromInline
   internal var nextReducer: B
 
-  @inlinable public init(previousReducer: A, nextReducer: B) {
+  @usableFromInline internal init(previousReducer: A, nextReducer: B) {
     self.previousReducer = previousReducer
     self.nextReducer = nextReducer
   }

--- a/Sources/SwiftDux/Reducer/Reducer.swift
+++ b/Sources/SwiftDux/Reducer/Reducer.swift
@@ -82,14 +82,15 @@ extension Reducer {
     }
     return reduceNext(state: state, action: action)
   }
+}
 
-  /// Compose two reducers together.
-  ///
-  /// - Parameters:
-  ///   - previousReducer: The first reducer to be called.
-  ///   - nextReducer: The second reducer to be called.
-  /// - Returns: A combined reducer.
-  @inlinable public static func + <R>(previousReducer: Self, _ nextReducer: R) -> CombinedReducer<State, Self, R> where R: Reducer, R.State == State {
-    CombinedReducer(previousReducer: previousReducer, nextReducer: nextReducer)
-  }
+/// Compose two reducers together.
+///
+/// - Parameters:
+///   - previousReducer: The first reducer to be called.
+///   - nextReducer: The second reducer to be called.
+/// - Returns: A combined reducer.
+@inlinable public func + <R1, R2>(previousReducer: R1, _ nextReducer: R2) -> CompositeReducer<R1.State, R1, R2>
+where R1: Reducer, R2: Reducer, R1.State == R2.State {
+  CompositeReducer(previousReducer: previousReducer, nextReducer: nextReducer)
 }

--- a/Sources/SwiftDux/Store/StateStorable.swift
+++ b/Sources/SwiftDux/Store/StateStorable.swift
@@ -40,3 +40,21 @@ extension StateStorable where State: Equatable {
     publish { $0 }
   }
 }
+
+extension StateStorable where Self: ActionDispatcher {
+
+  /// Create a proxy of the `StateStorable` for a given type or protocol.
+  ///
+  /// - Parameters:
+  ///   - stateType: The type of state for the proxy. This must be a type that the store adheres to.
+  ///   - dispatcher: An optional dispatcher for the proxy.
+  /// - Returns: A proxy object if the state type matches, otherwise nil.
+  @inlinable public func proxy<T>(for stateType: T.Type, dispatcher: ActionDispatcher? = nil) -> StoreProxy<T>? {
+    guard state is T else { return nil }
+    return StoreProxy<T>(
+      getState: { self.state as! T },
+      didChange: didChange,
+      dispatcher: dispatcher ?? self
+    )
+  }
+}

--- a/Sources/SwiftDux/UI/Extensions/Environment+ActionDispatcher.swift
+++ b/Sources/SwiftDux/UI/Extensions/Environment+ActionDispatcher.swift
@@ -7,6 +7,11 @@ internal struct NoopActionDispatcher: ActionDispatcher {
   func send(_ action: Action) {
     print("Tried dispatching an action `\(action)` without providing a store object.")
   }
+
+  func sendAsCancellable(_ action: Action) -> Cancellable {
+    print("Tried dispatching an action `\(action)` without providing a store object.")
+    return AnyCancellable {}
+  }
 }
 
 internal struct ActionDispatcherKey: EnvironmentKey {

--- a/Sources/SwiftDux/UI/Extensions/Environment+AnyStore.swift
+++ b/Sources/SwiftDux/UI/Extensions/Environment+AnyStore.swift
@@ -24,6 +24,10 @@ internal final class AnyStoreWrapper<T>: AnyStore {
   func send(_ action: Action) {
     store.send(action)
   }
+
+  func sendAsCancellable(_ action: Action) -> Cancellable {
+    store.sendAsCancellable(action)
+  }
 }
 
 struct NoopAnyStore: AnyStore {
@@ -33,6 +37,10 @@ struct NoopAnyStore: AnyStore {
 
   func send(_ action: Action) {
     // Do nothing
+  }
+
+  func sendAsCancellable(_ action: Action) -> Cancellable {
+    AnyCancellable {}
   }
 }
 

--- a/Sources/SwiftDux/UI/ViewModifiers/OnActionViewModifier.swift
+++ b/Sources/SwiftDux/UI/ViewModifiers/OnActionViewModifier.swift
@@ -34,6 +34,10 @@ extension OnActionViewModifier {
       guard let action = actionModifier(action) else { return }
       nextDispatcher.send(action)
     }
+
+    func sendAsCancellable(_ action: Action) -> Cancellable {
+      nextDispatcher.sendAsCancellable(action)
+    }
   }
 }
 

--- a/Sources/SwiftDux/UI/ViewModifiers/OnAppearDispatchViewModifier.swift
+++ b/Sources/SwiftDux/UI/ViewModifiers/OnAppearDispatchViewModifier.swift
@@ -33,7 +33,7 @@ public struct OnAppearDispatchActionPlanViewModifier: ViewModifier {
     content
       .onAppear {
         guard cancellable == nil else { return }
-        self.cancellable = action.sendAsCancellable(dispatch)
+        self.cancellable = dispatch.sendAsCancellable(action)
       }
       .onDisappear {
         if cancelOnDisappear {

--- a/Tests/SwiftDuxTests/Action/ActionPlanTests.swift
+++ b/Tests/SwiftDuxTests/Action/ActionPlanTests.swift
@@ -67,23 +67,21 @@ final class ActionPlanTests: XCTestCase {
   
   func testCancellableActionPlan() {
     let expectation = XCTestExpectation(description: "Expect one cancellation")
+    expectation.isInverted = true
     
-    let actionPlan = ActionPlan<TestState> { store, completed in
-      let cancellable = Just(TestAction.actionB)
-        .delay(for: .seconds(300), scheduler: RunLoop.main)
-        .send(to: store)
-      
-      return AnyCancellable { [cancellable] in
-        cancellable.cancel()
-        expectation.fulfill()
-      }
+    let actionPlan = ActionPlan<TestState> { store in
+      Just(TestAction.actionB)
+        .delay(for: .seconds(1), scheduler: RunLoop.main)
+        .handleEvents(receiveOutput: { action in
+          expectation.fulfill()
+        })
     }
     
     let cancellable = store.sendAsCancellable(actionPlan)
     
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
         cancellable.cancel()
-        expectation.fulfill()
+        //expectation.fulfill()
     }
     
     wait(for: [expectation], timeout: 5.0)
@@ -99,7 +97,7 @@ final class ActionPlanTests: XCTestCase {
     let actionPlanC = ActionPlan<TestState> { store in
       store.send(TestAction.actionB)
     }
-    let chainedActionPlan = actionPlanA.then(actionPlanB).then(actionPlanC)
+    let chainedActionPlan = actionPlanA + actionPlanB + actionPlanC
     
     _ = store.sendAsCancellable(chainedActionPlan)
     
@@ -117,8 +115,8 @@ final class ActionPlanTests: XCTestCase {
     let actionPlanB = ActionPlan<TestState> { store in
       store.send(TestAction.actionA)
     }
-    let actionPlanC = ActionPlan<TestState> { store, next in
-      Just(TestAction.actionB).send(to: store, receivedCompletion: next)
+    let actionPlanC = ActionPlan<TestState> { store in
+      Just(TestAction.actionB)
     }
     let expectation = XCTestExpectation(description: "Expect one cancellation")
     let chainedActionPlan = actionPlanA.then(actionPlanB).then(actionPlanC).then { 

--- a/Tests/SwiftDuxTests/Middleware/CompositeMiddlwareTests.swift
+++ b/Tests/SwiftDuxTests/Middleware/CompositeMiddlwareTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+import Combine
+@testable import SwiftDux
+
+final class CompositeMiddlewareTests: XCTestCase {
+  
+  func testCompiningMiddleware() {
+    let middlewareA = MiddlewareA()
+    let middlewareB = MiddlewareB()
+    let store = Store<TestState>(state: TestState(), reducer: TestReducer(), middleware: middlewareA + middlewareB)
+    store.send(TestAction.setTextUnmodified("123"))
+    XCTAssertEqual(
+      store.state.text,
+      "123"
+    )
+    store.send(TestAction.setText("123"))
+    XCTAssertEqual(
+      store.state.text,
+      "123AB"
+    )
+  }
+  
+  static var allTests = [
+    ("testCombiningReducers", testCompiningMiddleware)
+  ]
+}
+
+extension CompositeMiddlewareTests {
+  
+  struct TestState: Equatable {
+    var text: String = ""
+  }
+  
+  enum TestAction: Action {
+    case setText(String)
+    case setTextUnmodified(String)
+  }
+  
+  final class TestReducer: Reducer {
+    func reduce(state: TestState, action: TestAction) -> TestState {
+      var state = state
+      switch action {
+      case .setText(let text):
+        state.text = text
+      case .setTextUnmodified(let text):
+        state.text = text
+      }
+      return state
+    }
+  }
+  
+  final class MiddlewareA: Middleware {
+    func run(store: StoreProxy<TestState>, action: Action) {
+      if case .setText(let text) = action as? TestAction {
+        store.next(TestAction.setText(text + "A"))
+      } else {
+        store.next(action)
+      }
+    }
+  }
+  
+  final class MiddlewareB: Middleware {
+    func run(store: StoreProxy<TestState>, action: Action) {
+      if case .setText(let text) = action as? TestAction {
+        store.next(TestAction.setText(text + "B"))
+      } else {
+        store.next(action)
+      }
+    }
+  }
+}

--- a/Tests/SwiftDuxTests/Reducer/CompositeReducerTests.swift
+++ b/Tests/SwiftDuxTests/Reducer/CompositeReducerTests.swift
@@ -2,10 +2,12 @@ import XCTest
 import Combine
 @testable import SwiftDux
 
-final class CombinedReducerTests: XCTestCase {
+final class CompositeReducerTests: XCTestCase {
   
   func testCombiningReducers() {
-    let reducer = ReducerA() + ReducerB()
+    let reducerA = ReducerA()
+    let reducerB = ReducerB()
+    let reducer = reducerA + reducerB
     XCTAssertEqual(
       reducer.reduceAny(state: TestState(), action: TestAction.setStateA("123")),
       TestState(stateA: "123")
@@ -21,7 +23,7 @@ final class CombinedReducerTests: XCTestCase {
   ]
 }
 
-extension CombinedReducerTests {
+extension CompositeReducerTests {
   
   struct TestState: Equatable {
     var stateA: String = ""

--- a/Tests/SwiftDuxTests/Store/StoreTests.swift
+++ b/Tests/SwiftDuxTests/Store/StoreTests.swift
@@ -23,8 +23,8 @@ final class StoreTests: XCTestCase {
   }
   
   func testActionPlans() {
-    store.send(ActionPlan<TestSendingState> { store, next in
-      Just(TestSendingAction.setText("1234")).send(to: store, receivedCompletion: next)
+    store.send(ActionPlan<TestSendingState> { store in
+      Just(TestSendingAction.setText("1234"))
     })
     XCTAssertEqual(store.state.text, "1234")
   }


### PR DESCRIPTION
This PR refactors how actions may be chained together. It uses a new CompositeAction type that generates the chain via a publisher.

# Work Performed
- Added a new CompositeAction to chain multiple actions together.
- Added '+' operator to combine actions.
- Simplified the cancellable action workflow.
- RunnableAction now returns a publisher instead of a cancellable.

```swift
let compositeAction = simpleAction + myActionPlan + anotherAction
store.send(compositeAction)
```