### PR TITLE
Improve the Middleware and Reducer pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run tests
         run: |
           swift package generate-xcodeproj --enable-code-coverage
-          xcodebuild -project SwiftDux.xcodeproj -scheme SwiftDux-Package -destination "${destination}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO test
+          xcodebuild -project SwiftDux.xcodeproj -scheme SwiftDux-Package -destination "${destination}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test
           bash <(curl -s https://codecov.io/bash) -J 'SwiftDux'
         env:
           destination: ${{ matrix.destination }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           mint install apple/swift-format@0.50300.0
       - name: Check code formatting
         run: |
-          swift-format -r -m lint Sources
+          ./scripts/lint.sh
       - name: Run tests
         run: |
           swift package generate-xcodeproj --enable-code-coverage

--- a/Sources/SwiftDux/Action/Action.swift
+++ b/Sources/SwiftDux/Action/Action.swift
@@ -38,7 +38,7 @@ extension Action {
   ///
   /// - Parameter block: A block of code to execute once the previous action has completed.
   /// - Returns: A composite action.
-  @inlinable public func then(_ block: @escaping ()->Void) -> CompositeAction {
+  @inlinable public func then(_ block: @escaping () -> Void) -> CompositeAction {
     then(ActionPlan<Any> { _ in block() })
   }
 }
@@ -52,9 +52,9 @@ public struct EmptyAction: Action {
 /// A closure that dispatches an action.
 ///
 /// - Parameter action: The action to dispatch.
-public typealias SendAction = (Action)->Void
+public typealias SendAction = (Action) -> Void
 
 /// A closure that dispatches a cancellable action.
 ///
 /// - Parameter action: The action to dispatch.
-public typealias SendCancellableAction = (Action)->Cancellable
+public typealias SendCancellableAction = (Action) -> Cancellable

--- a/Sources/SwiftDux/Action/ActionDispatcher.swift
+++ b/Sources/SwiftDux/Action/ActionDispatcher.swift
@@ -28,3 +28,4 @@ extension ActionDispatcher {
     send(action)
   }
 }
+

--- a/Sources/SwiftDux/Action/ActionDispatcher.swift
+++ b/Sources/SwiftDux/Action/ActionDispatcher.swift
@@ -28,4 +28,3 @@ extension ActionDispatcher {
     send(action)
   }
 }
-

--- a/Sources/SwiftDux/Action/ActionDispatcherProxy.swift
+++ b/Sources/SwiftDux/Action/ActionDispatcherProxy.swift
@@ -5,8 +5,7 @@ import Foundation
 public struct ActionDispatcherProxy: ActionDispatcher {
   @usableFromInline internal var sendBlock: SendAction
   @usableFromInline internal var sendAsCancellableBlock: SendCancellableAction
-  
-  
+
   /// Initiate a new BlockActionDispatcher.
   ///
   /// - Parameters:
@@ -16,11 +15,11 @@ public struct ActionDispatcherProxy: ActionDispatcher {
     self.sendBlock = send
     self.sendAsCancellableBlock = sendAsCancellable
   }
-  
-  @inlinable  public func send(_ action: Action) {
+
+  @inlinable public func send(_ action: Action) {
     sendBlock(action)
   }
-  
+
   @inlinable public func sendAsCancellable(_ action: Action) -> Cancellable {
     sendAsCancellableBlock(action)
   }

--- a/Sources/SwiftDux/Action/ActionDispatcherProxy.swift
+++ b/Sources/SwiftDux/Action/ActionDispatcherProxy.swift
@@ -1,0 +1,27 @@
+import Combine
+import Foundation
+
+/// A concrete `ActionDispatcher` that can acts as a proxy.
+public struct ActionDispatcherProxy: ActionDispatcher {
+  @usableFromInline internal var sendBlock: SendAction
+  @usableFromInline internal var sendAsCancellableBlock: SendCancellableAction
+  
+  
+  /// Initiate a new BlockActionDispatcher.
+  ///
+  /// - Parameters:
+  ///   - send: A closure to dispatch an action.
+  ///   - sendAsCancellable: A closure to dispatch a cancellable action.
+  public init(send: @escaping SendAction, sendAsCancellable: @escaping SendCancellableAction) {
+    self.sendBlock = send
+    self.sendAsCancellableBlock = sendAsCancellable
+  }
+  
+  @inlinable  public func send(_ action: Action) {
+    sendBlock(action)
+  }
+  
+  @inlinable public func sendAsCancellable(_ action: Action) -> Cancellable {
+    sendAsCancellableBlock(action)
+  }
+}

--- a/Sources/SwiftDux/Action/ActionPlan.swift
+++ b/Sources/SwiftDux/Action/ActionPlan.swift
@@ -37,15 +37,29 @@ public struct ActionPlan<State>: RunnableAction {
   @usableFromInline
   internal var body: Body
 
-  /// Create an action plan that returns a publisher.
+  /// Initiate an action plan that returns a publisher of actions.
   ///
   /// - Parameter body: The body of the action plan.
-  @inlinable public init<P>(_ body: @escaping (StoreProxy<State>) -> P) where P: Publisher, P.Output == Action, P.Failure == Never {
+  @inlinable public init<P>(_ body: @escaping (StoreProxy<State>)->P) where P: Publisher, P.Output == Action, P.Failure == Never {
     self.body = { store in body(store).eraseToAnyPublisher() }
   }
-
-  /// Create a synchronous action plan. The plan expects to be completed once the body has returned.
+  
+  /// Initiate an asynchronous action plan that completes after the first emitted void value from its publisher.
   ///
+  /// Use this method to wrap asynchronous code in a publisher like `Future<Void, Never>`.
+  /// - Parameter body: The body of the action plan.
+  @inlinable public init<P>(_ body: @escaping (StoreProxy<State>)->P) where P: Publisher, P.Output == Void, P.Failure == Never {
+    self.body = { store in
+        body(store)
+          .first()
+          .compactMap { _ -> Action? in nil }
+          .eraseToAnyPublisher()
+    }
+  }
+
+  /// Initiate a synchronous action plan.
+  ///
+  /// The plan expects to complete once the body has returned.
   /// - Parameter body: The body of the action plan.
   @inlinable public init(_ body: @escaping (StoreProxy<State>) -> Void) {
     self.body = { store in
@@ -54,26 +68,7 @@ public struct ActionPlan<State>: RunnableAction {
     }
   }
 
-  /// Create an asynchronous action plan that returns a cancellable.
-  ///
-  /// - Parameter body: The body of the action plan.
-  @inlinable public init(_ body: @escaping (StoreProxy<State>, @escaping () -> Void) -> Cancellable) {
-    self.body = { store in
-      var cancellable: Cancellable? = nil
-      return Deferred {
-        Future<Void, Never> { promise in
-          cancellable = body(store) {
-            promise(.success(()))
-          }
-        }
-        .compactMap { _ -> Action? in nil }
-      }
-      .handleEvents(receiveCancel: { cancellable?.cancel() })
-      .eraseToAnyPublisher()
-    }
-  }
-
-  @inlinable public func run<T>(store: Store<T>) -> AnyPublisher<Action, Never> {
+  @inlinable public func run<T>(store: StoreProxy<T>) -> AnyPublisher<Action, Never> {
     guard let storeProxy = store.proxy(for: State.self) else {
       fatalError("Store does not support type `\(State.self)` from ActionPlan.")
     }

--- a/Sources/SwiftDux/Action/ActionPlan.swift
+++ b/Sources/SwiftDux/Action/ActionPlan.swift
@@ -40,20 +40,20 @@ public struct ActionPlan<State>: RunnableAction {
   /// Initiate an action plan that returns a publisher of actions.
   ///
   /// - Parameter body: The body of the action plan.
-  @inlinable public init<P>(_ body: @escaping (StoreProxy<State>)->P) where P: Publisher, P.Output == Action, P.Failure == Never {
+  @inlinable public init<P>(_ body: @escaping (StoreProxy<State>) -> P) where P: Publisher, P.Output == Action, P.Failure == Never {
     self.body = { store in body(store).eraseToAnyPublisher() }
   }
-  
+
   /// Initiate an asynchronous action plan that completes after the first emitted void value from its publisher.
   ///
   /// Use this method to wrap asynchronous code in a publisher like `Future<Void, Never>`.
   /// - Parameter body: The body of the action plan.
-  @inlinable public init<P>(_ body: @escaping (StoreProxy<State>)->P) where P: Publisher, P.Output == Void, P.Failure == Never {
+  @inlinable public init<P>(_ body: @escaping (StoreProxy<State>) -> P) where P: Publisher, P.Output == Void, P.Failure == Never {
     self.body = { store in
-        body(store)
-          .first()
-          .compactMap { _ -> Action? in nil }
-          .eraseToAnyPublisher()
+      body(store)
+        .first()
+        .compactMap { _ -> Action? in nil }
+        .eraseToAnyPublisher()
     }
   }
 

--- a/Sources/SwiftDux/Action/ActionSubscriber.swift
+++ b/Sources/SwiftDux/Action/ActionSubscriber.swift
@@ -7,7 +7,6 @@ final internal class ActionSubscriber: Subscriber {
   typealias ReceivedCompletion = () -> Void
 
   private let actionDispatcher: ActionDispatcher
-  private let receivedCompletion: ReceivedCompletion?
   private var subscription: Subscription? = nil {
     willSet {
       guard let subscription = subscription else { return }
@@ -15,9 +14,8 @@ final internal class ActionSubscriber: Subscriber {
     }
   }
 
-  internal init(actionDispatcher: ActionDispatcher, receivedCompletion: ReceivedCompletion?) {
+  internal init(actionDispatcher: ActionDispatcher) {
     self.actionDispatcher = actionDispatcher
-    self.receivedCompletion = receivedCompletion
   }
 
   public func receive(subscription: Subscription) {
@@ -31,7 +29,6 @@ final internal class ActionSubscriber: Subscriber {
   }
 
   public func receive(completion: Subscribers.Completion<Never>) {
-    receivedCompletion?()
     subscription = nil
   }
 
@@ -49,14 +46,9 @@ extension Publisher where Output == Action, Failure == Never {
   ///   - actionDispatcher: The ActionDispatcher
   ///   - receivedCompletion: An optional block called when the publisher completes.
   /// - Returns: A cancellable to unsubscribe.
-  public func send(to actionDispatcher: ActionDispatcher, receivedCompletion: (() -> Void)? = nil) -> AnyCancellable {
-    let subscriber = ActionSubscriber(
-      actionDispatcher: actionDispatcher,
-      receivedCompletion: receivedCompletion
-    )
+  public func send(to actionDispatcher: ActionDispatcher) -> AnyCancellable {
+    let subscriber = ActionSubscriber(actionDispatcher: actionDispatcher)
     self.subscribe(subscriber)
-    return AnyCancellable { [subscriber] in
-      subscriber.cancel()
-    }
+    return AnyCancellable { subscriber.cancel() }
   }
 }

--- a/Sources/SwiftDux/Action/ActionSubscriber.swift
+++ b/Sources/SwiftDux/Action/ActionSubscriber.swift
@@ -42,9 +42,7 @@ extension Publisher where Output == Action, Failure == Never {
 
   /// Subscribe to a publisher of actions, and send the results to an action dispatcher.
   ///
-  /// - Parameters:
-  ///   - actionDispatcher: The ActionDispatcher
-  ///   - receivedCompletion: An optional block called when the publisher completes.
+  /// - Parameter actionDispatcher: The ActionDispatcher
   /// - Returns: A cancellable to unsubscribe.
   public func send(to actionDispatcher: ActionDispatcher) -> AnyCancellable {
     let subscriber = ActionSubscriber(actionDispatcher: actionDispatcher)

--- a/Sources/SwiftDux/Action/CompositeAction.swift
+++ b/Sources/SwiftDux/Action/CompositeAction.swift
@@ -31,7 +31,6 @@ public struct CompositeAction: RunnableAction {
   }
 }
 
-
 /// Chain two actions together as a composite type.
 ///
 /// - Parameters:

--- a/Sources/SwiftDux/Action/RunnableAction.swift
+++ b/Sources/SwiftDux/Action/RunnableAction.swift
@@ -9,5 +9,5 @@ public protocol RunnableAction: Action {
   ///
   /// - Parameter store: The store that the action has been dispatched to.
   /// - Returns: A cancellable object.
-  func run<T>(store: Store<T>) -> AnyPublisher<Action, Never>
+  func run<T>(store: StoreProxy<T>) -> AnyPublisher<Action, Never>
 }

--- a/Sources/SwiftDux/Middleware/CompositeMiddleware.swift
+++ b/Sources/SwiftDux/Middleware/CompositeMiddleware.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// Use the '+' operator to combine two or more middleware together.
 public struct CompositeMiddleware<State, A, B>: Middleware where A: Middleware, B: Middleware, A.State == State, B.State == State {
-  private var previousMiddleware: A
-  private var nextMiddleware: B
+  @usableFromInline internal var previousMiddleware: A
+  @usableFromInline internal var nextMiddleware: B
 
   @usableFromInline internal init(previousMiddleware: A, nextMiddleware: B) {
     self.previousMiddleware = previousMiddleware
@@ -11,14 +11,21 @@ public struct CompositeMiddleware<State, A, B>: Middleware where A: Middleware, 
   }
 
   /// Unimplemented. It simply calls `store.next(_:)`.
-  @inlinable public func run(store: StoreProxy<State>, action: Action) {
-    store.next(action)
+  @inlinable public func run(store: StoreProxy<State>, action: Action) -> Action? {
+    guard let action = previousMiddleware.run(store: store, action: action) else {
+      return nil
+    }
+    return nextMiddleware.run(store: store, action: action)
   }
+}
 
-  /// Apply the middleware to a store proxy.
-  /// - Parameter store: The store proxy.
-  /// - Returns: A SendAction function that performs the middleware for the provided store proxy.
-  public func compile(store: StoreProxy<State>) -> SendAction {
-    previousMiddleware(store: StoreProxy(proxy: store, next: nextMiddleware(store: store)))
-  }
+/// Compose two middleware together.
+///
+/// - Parameters:
+///   - previousMiddleware: The  middleware to be called first.
+///   - nextMiddleware: The next middleware to call.
+/// - Returns: The combined middleware.
+@inlinable public func + <M1, M2>(previousMiddleware: M1, _ nextMiddleware: M2) -> CompositeMiddleware<M1.State, M1, M2>
+where M1: Middleware, M2: Middleware, M1.State == M2.State {
+  CompositeMiddleware(previousMiddleware: previousMiddleware, nextMiddleware: nextMiddleware)
 }

--- a/Sources/SwiftDux/Middleware/HandleActionMiddleware.swift
+++ b/Sources/SwiftDux/Middleware/HandleActionMiddleware.swift
@@ -3,15 +3,14 @@ import Foundation
 
 /// A simple middleware to perform any handling on a dispatched action.
 public final class HandleActionMiddleware<State>: Middleware {
-  @usableFromInline
-  internal var perform: (StoreProxy<State>, Action) -> Void
+  @usableFromInline internal var perform: (StoreProxy<State>, Action) -> Action?
 
   /// - Parameter body: The block to call when an action is dispatched.
-  @inlinable public init(perform: @escaping (StoreProxy<State>, Action) -> Void) {
+  @inlinable public init(perform: @escaping (StoreProxy<State>, Action) -> Action?) {
     self.perform = perform
   }
 
-  @inlinable public func run(store: StoreProxy<State>, action: Action) {
+  @inlinable public func run(store: StoreProxy<State>, action: Action) -> Action? {
     perform(store, action)
   }
 }

--- a/Sources/SwiftDux/Middleware/Middleware.swift
+++ b/Sources/SwiftDux/Middleware/Middleware.swift
@@ -16,6 +16,7 @@ public protocol Middleware {
   /// - Parameters:
   ///   - store: The store object. Use `store.next` when the middleware is complete.
   ///   - action: The latest dispatched action to process.
+  /// - Returns: An optional action to pass to the next middleware.
   func run(store: StoreProxy<State>, action: Action) -> Action?
 
   /// Compiles the middleware into a SendAction closure.

--- a/Sources/SwiftDux/Middleware/Middleware.swift
+++ b/Sources/SwiftDux/Middleware/Middleware.swift
@@ -1,16 +1,13 @@
 import Combine
 import Foundation
 
-/// Middleware perform actions on the the store when actions are dispatched to it.
+/// Extends the store functionality by providing a middle layer between dispatched actions and the store's reducer.
 ///
 /// Before an action is given to a reducer, middleware have an opportunity to handle it
 /// themselves. They may dispatch their own actions, transform the current action, or
-/// block an incoming ones from continuing.
+/// block it entirely.
 ///
 /// Middleware can also be used to set up external hooks from services.
-///
-/// For a reducer's own state and actions, implement the `reduce(state:action:)`.
-/// For subreducers, implement the `reduceNext(state:action:)` method.
 public protocol Middleware {
   associatedtype State
 
@@ -19,9 +16,10 @@ public protocol Middleware {
   /// - Parameters:
   ///   - store: The store object. Use `store.next` when the middleware is complete.
   ///   - action: The latest dispatched action to process.
-  func run(store: StoreProxy<State>, action: Action)
+  func run(store: StoreProxy<State>, action: Action) -> Action?
 
   /// Compiles the middleware into a SendAction closure.
+  ///
   /// - Parameter store: A reference to the store used by the middleware.
   /// - Returns: The SendAction that performs the middleware.
   func compile(store: StoreProxy<State>) -> SendAction
@@ -30,6 +28,7 @@ public protocol Middleware {
 extension Middleware {
 
   /// Apply the middleware to a store proxy.
+  ///
   /// - Parameter store: The store proxy.
   /// - Returns: A SendAction function that performs the middleware for the provided store proxy.
   @inlinable public func callAsFunction(store: StoreProxy<State>) -> SendAction {
@@ -37,23 +36,13 @@ extension Middleware {
   }
 
   @inlinable public func compile(store: StoreProxy<State>) -> SendAction {
-    { action in self.run(store: store, action: action) }
+    { action in _ = self.run(store: store, action: action) }
   }
-}
-
-/// Compose two middleware together.
-/// - Parameters:
-///   - previousMiddleware: The  middleware to be called first.
-///   - nextMiddleware: The next middleware to call.
-/// - Returns: The combined middleware.
-@inlinable public func + <M1, M2>(previousMiddleware: M1, _ nextMiddleware: M2) -> CompositeMiddleware<M1.State, M1, M2>
-where M1: Middleware, M2: Middleware, M1.State == M2.State {
-  CompositeMiddleware(previousMiddleware: previousMiddleware, nextMiddleware: nextMiddleware)
 }
 
 internal final class NoopMiddleware<State>: Middleware {
 
-  @inlinable func run(store: StoreProxy<State>, action: Action) {
-    store.next(action)
+  @inlinable func run(store: StoreProxy<State>, action: Action) -> Action? {
+    action
   }
 }

--- a/Sources/SwiftDux/Middleware/ReduceMiddleware.swift
+++ b/Sources/SwiftDux/Middleware/ReduceMiddleware.swift
@@ -1,0 +1,8 @@
+//
+//  ReduceMiddleware.swift
+//  SwiftDuxTests
+//
+//  Created by Steven Lambion on 11/19/20.
+//
+
+import Foundation

--- a/Sources/SwiftDux/Middleware/ReducerMiddleware.swift
+++ b/Sources/SwiftDux/Middleware/ReducerMiddleware.swift
@@ -1,0 +1,15 @@
+// Reduces the state of a store with the provided action to produce a new state.
+internal final class ReducerMiddleware<State, RootReducer>: Middleware where RootReducer: Reducer, RootReducer.State == State {
+  let reducer: CompositeReducer<State, StoreReducer<State>, RootReducer>
+  let receivedState: (State)->()
+  
+  init(reducer: RootReducer, receivedState: @escaping (State)->()) {
+    self.reducer = StoreReducer() + reducer
+    self.receivedState = receivedState
+  }
+  
+  @inlinable func run(store: StoreProxy<State>, action: Action) -> Action? {
+    receivedState(reducer(state: store.state, action: action))
+    return nil
+  }
+}

--- a/Sources/SwiftDux/Middleware/ReducerMiddleware.swift
+++ b/Sources/SwiftDux/Middleware/ReducerMiddleware.swift
@@ -1,13 +1,13 @@
 // Reduces the state of a store with the provided action to produce a new state.
 internal final class ReducerMiddleware<State, RootReducer>: Middleware where RootReducer: Reducer, RootReducer.State == State {
   let reducer: CompositeReducer<State, StoreReducer<State>, RootReducer>
-  let receivedState: (State)->()
-  
-  init(reducer: RootReducer, receivedState: @escaping (State)->()) {
+  let receivedState: (State) -> Void
+
+  init(reducer: RootReducer, receivedState: @escaping (State) -> Void) {
     self.reducer = StoreReducer() + reducer
     self.receivedState = receivedState
   }
-  
+
   @inlinable func run(store: StoreProxy<State>, action: Action) -> Action? {
     receivedState(reducer(state: store.state, action: action))
     return nil

--- a/Sources/SwiftDux/Reducer/CompositeReducer.swift
+++ b/Sources/SwiftDux/Reducer/CompositeReducer.swift
@@ -2,11 +2,8 @@ import Foundation
 
 /// Use the '+' operator to combine two or more reducers together.
 public final class CompositeReducer<State, A, B>: Reducer where A: Reducer, B: Reducer, A.State == State, B.State == State {
-  @usableFromInline
-  internal var previousReducer: A
-
-  @usableFromInline
-  internal var nextReducer: B
+  @usableFromInline internal var previousReducer: A
+  @usableFromInline internal var nextReducer: B
 
   @usableFromInline internal init(previousReducer: A, nextReducer: B) {
     self.previousReducer = previousReducer
@@ -16,4 +13,15 @@ public final class CompositeReducer<State, A, B>: Reducer where A: Reducer, B: R
   @inlinable public func reduceAny(state: State, action: Action) -> State {
     nextReducer(state: previousReducer(state: state, action: action), action: action)
   }
+}
+
+/// Compose two reducers together.
+///
+/// - Parameters:
+///   - previousReducer: The first reducer to be called.
+///   - nextReducer: The second reducer to be called.
+/// - Returns: A combined reducer.
+@inlinable public func + <R1, R2>(previousReducer: R1, _ nextReducer: R2) -> CompositeReducer<R1.State, R1, R2>
+where R1: Reducer, R2: Reducer, R1.State == R2.State {
+  CompositeReducer(previousReducer: previousReducer, nextReducer: nextReducer)
 }

--- a/Sources/SwiftDux/Reducer/Reducer.swift
+++ b/Sources/SwiftDux/Reducer/Reducer.swift
@@ -54,7 +54,7 @@ extension Reducer {
   ///   - action: Any kind of action.
   /// - Returns: A new immutable state
   @inlinable public func reduceAny(state: State, action: Action) -> State {
-    guard let reducerAction = action as? ReducerAction  else {
+    guard let reducerAction = action as? ReducerAction else {
       return state
     }
     return reduce(state: state, action: reducerAction)

--- a/Sources/SwiftDux/Reducer/Reducer.swift
+++ b/Sources/SwiftDux/Reducer/Reducer.swift
@@ -3,11 +3,7 @@ import Foundation
 /// Performs an action on a given state and returns a whole new version.
 ///
 /// A store is given a single root `Reducer`. As it's sent actions, it runs the reducer to
-/// update the application's state. The reducer can have subreducers to separate code
-/// out into modular parts.
-///
-/// For a reducer's own state and actions, implement the `reduce(state:action:)`.
-/// For subreducers, implement the `reduceNext(state:action:)` method.
+/// update the application's state.
 public protocol Reducer {
 
   /// The type of state that the `Reducer` is able to mutate.
@@ -23,14 +19,6 @@ public protocol Reducer {
   ///   - action: An action that the reducer is expected to perform on the state.
   /// - Returns: A new immutable state.
   func reduce(state: State, action: ReducerAction) -> State
-
-  /// Delegates an action to a subreducer.
-  ///
-  /// - Parameters
-  ///   - state: The state to reduce.
-  ///   - action: An unknown action that a subreducer may support.
-  /// - Returns: A new immutable state.
-  func reduceNext(state: State, action: Action) -> State
 
   /// Send any kind of action to a reducer. The recuder will determine what it can do with
   /// the action.
@@ -58,16 +46,6 @@ extension Reducer {
     state
   }
 
-  /// Default implementation. Returns the state without modifying it.
-  ///
-  /// - Parameters
-  ///   - state: The state to reduce.
-  ///   - action: An unknown action that a subreducer may support.
-  /// - Returns: A new immutable state.
-  @inlinable public func reduceNext(state: State, action: Action) -> State {
-    state
-  }
-
   /// Send any kind of action to a reducer. The recuder will determine what it can do with
   /// the action.
   ///
@@ -76,21 +54,9 @@ extension Reducer {
   ///   - action: Any kind of action.
   /// - Returns: A new immutable state
   @inlinable public func reduceAny(state: State, action: Action) -> State {
-    var state = state
-    if let reducerAction = action as? ReducerAction {
-      state = reduce(state: state, action: reducerAction)
+    guard let reducerAction = action as? ReducerAction  else {
+      return state
     }
-    return reduceNext(state: state, action: action)
+    return reduce(state: state, action: reducerAction)
   }
-}
-
-/// Compose two reducers together.
-///
-/// - Parameters:
-///   - previousReducer: The first reducer to be called.
-///   - nextReducer: The second reducer to be called.
-/// - Returns: A combined reducer.
-@inlinable public func + <R1, R2>(previousReducer: R1, _ nextReducer: R2) -> CompositeReducer<R1.State, R1, R2>
-where R1: Reducer, R2: Reducer, R1.State == R2.State {
-  CompositeReducer(previousReducer: previousReducer, nextReducer: nextReducer)
 }

--- a/Sources/SwiftDux/Store/StateStorable.swift
+++ b/Sources/SwiftDux/Store/StateStorable.swift
@@ -42,6 +42,20 @@ extension StateStorable where State: Equatable {
 }
 
 extension StateStorable where Self: ActionDispatcher {
+  
+  /// Create a proxy of the `StateStorable` for a given type or protocol.
+  ///
+  /// - Parameters:
+  ///   - stateType: The type of state for the proxy. This must be a type that the store adheres to.
+  ///   - dispatcher: An optional dispatcher for the proxy.
+  /// - Returns: A proxy object if the state type matches, otherwise nil.
+  @inlinable public func proxy(dispatcher: ActionDispatcher? = nil) -> StoreProxy<State> {
+    StoreProxy<State>(
+      getState: { state },
+      didChange: didChange,
+      dispatcher: dispatcher ?? self
+    )
+  }
 
   /// Create a proxy of the `StateStorable` for a given type or protocol.
   ///
@@ -52,7 +66,7 @@ extension StateStorable where Self: ActionDispatcher {
   @inlinable public func proxy<T>(for stateType: T.Type, dispatcher: ActionDispatcher? = nil) -> StoreProxy<T>? {
     guard state is T else { return nil }
     return StoreProxy<T>(
-      getState: { self.state as! T },
+      getState: { state as! T },
       didChange: didChange,
       dispatcher: dispatcher ?? self
     )

--- a/Sources/SwiftDux/Store/StateStorable.swift
+++ b/Sources/SwiftDux/Store/StateStorable.swift
@@ -42,12 +42,10 @@ extension StateStorable where State: Equatable {
 }
 
 extension StateStorable where Self: ActionDispatcher {
-  
+
   /// Create a proxy of the `StateStorable` for a given type or protocol.
   ///
-  /// - Parameters:
-  ///   - stateType: The type of state for the proxy. This must be a type that the store adheres to.
-  ///   - dispatcher: An optional dispatcher for the proxy.
+  /// - Parameter dispatcher: An optional dispatcher for the proxy.
   /// - Returns: A proxy object if the state type matches, otherwise nil.
   @inlinable public func proxy(dispatcher: ActionDispatcher? = nil) -> StoreProxy<State> {
     StoreProxy<State>(

--- a/Sources/SwiftDux/Store/Store.swift
+++ b/Sources/SwiftDux/Store/Store.swift
@@ -22,19 +22,8 @@ public final class Store<State>: StateStorable {
   ///   - reducer: A reducer that mutates the state as actions are dispatched to it.
   ///   - middleware: A middleware plugin.
   public init<R, M>(state: State, reducer: R, middleware: M) where R: Reducer, R.State == State, M: Middleware, M.State == State {
-    let storeReducer = StoreReducer(rootReducer: reducer)
     self.state = state
-    self.reduce = middleware(
-      store: StoreProxy(
-        getState: { [unowned self] in self.state },
-        didChange: didChange,
-        dispatcher: self,
-        next: { [weak self] action in
-          guard let self = self else { return }
-          self.state = storeReducer(state: self.state, action: action)
-        }
-      )
-    )
+    self.reduce = compile(middleware: middleware + ReducerMiddleware(reducer: reducer) { [weak self] in self?.state = $0 })
     send(StoreAction<State>.prepare)
   }
 
@@ -45,6 +34,17 @@ public final class Store<State>: StateStorable {
   ///   - reducer: A reducer that mutates the state as actions are dispatched to it.
   public convenience init<R>(state: State, reducer: R) where R: Reducer, R.State == State {
     self.init(state: state, reducer: reducer, middleware: NoopMiddleware())
+  }
+  
+  private func compile<M>(middleware: M) -> SendAction where M: Middleware, M.State == State {
+    middleware(store: StoreProxy(
+      getState: { [unowned self] in self.state },
+      didChange: didChange,
+      dispatcher: ActionDispatcherProxy(
+        send: { [unowned self] in self.send($0) },
+        sendAsCancellable: { [unowned self] in self.sendAsCancellable($0) }
+      )
+    ))
   }
 }
 
@@ -66,7 +66,7 @@ extension Store: ActionDispatcher {
   /// - Returns: A cancellable object.
   @inlinable public func sendAsCancellable(_ action: Action) -> Cancellable {
     if let action = action as? RunnableAction {
-      return action.run(store: self).send(to: self)
+      return action.run(store: self.proxy()).send(to: self)
     }
     return Just(action).send(to: self)
   }
@@ -75,11 +75,12 @@ extension Store: ActionDispatcher {
   ///
   /// - Parameter action: The  action to perform.
   @usableFromInline internal func reduceRunnableAction(_ action: RunnableAction) {
-    var cancellable: Cancellable? = nil
-    cancellable = action.run(store: self).send(to: self) {
-      cancellable?.cancel()
-      cancellable = nil
-    }
+    var cancellable: AnyCancellable? = nil
+    cancellable = action.run(store: self.proxy())
+      .handleEvents(receiveCompletion: { _ in
+        cancellable?.cancel()
+        cancellable = nil
+      })
+      .send(to: self)
   }
-
 }

--- a/Sources/SwiftDux/Store/Store.swift
+++ b/Sources/SwiftDux/Store/Store.swift
@@ -35,16 +35,18 @@ public final class Store<State>: StateStorable {
   public convenience init<R>(state: State, reducer: R) where R: Reducer, R.State == State {
     self.init(state: state, reducer: reducer, middleware: NoopMiddleware())
   }
-  
+
   private func compile<M>(middleware: M) -> SendAction where M: Middleware, M.State == State {
-    middleware(store: StoreProxy(
-      getState: { [unowned self] in self.state },
-      didChange: didChange,
-      dispatcher: ActionDispatcherProxy(
-        send: { [unowned self] in self.send($0) },
-        sendAsCancellable: { [unowned self] in self.sendAsCancellable($0) }
+    middleware(
+      store: StoreProxy(
+        getState: { [unowned self] in self.state },
+        didChange: didChange,
+        dispatcher: ActionDispatcherProxy(
+          send: { [unowned self] in self.send($0) },
+          sendAsCancellable: { [unowned self] in self.sendAsCancellable($0) }
+        )
       )
-    ))
+    )
   }
 }
 

--- a/Sources/SwiftDux/Store/StoreProxy.swift
+++ b/Sources/SwiftDux/Store/StoreProxy.swift
@@ -8,9 +8,7 @@ import Foundation
 /// middleware don't have to worry about retaining the store. Instead, the proxy provides
 /// a safe API to access a weak reference to it.
 public struct StoreProxy<State>: StateStorable, ActionDispatcher {
-
-  @usableFromInline
-  internal var getState: () -> State
+  @usableFromInline internal var getState: () -> State
 
   /// Emits after the specified action was sent to the store.
   public var didChange: StorePublisher
@@ -18,10 +16,6 @@ public struct StoreProxy<State>: StateStorable, ActionDispatcher {
   /// Send an action to the next middleware
   @usableFromInline
   internal var dispatcher: ActionDispatcher
-
-  /// Send an action to the next middleware
-  @usableFromInline
-  internal var nextBlock: SendAction?
 
   /// Retrieves the latest state from the store.
   public var state: State {
@@ -31,20 +25,11 @@ public struct StoreProxy<State>: StateStorable, ActionDispatcher {
   @inlinable internal init(
     getState: @escaping () -> State,
     didChange: StorePublisher,
-    dispatcher: ActionDispatcher,
-    next: SendAction? = nil
+    dispatcher: ActionDispatcher
   ) {
     self.getState = getState
     self.didChange = didChange
     self.dispatcher = dispatcher
-    self.nextBlock = next
-  }
-
-  @inlinable internal init(proxy: StoreProxy<State>, dispatcher: ActionDispatcher? = nil, next: SendAction? = nil) {
-    self.getState = proxy.getState
-    self.didChange = proxy.didChange
-    self.dispatcher = dispatcher ?? proxy
-    self.nextBlock = next ?? proxy.nextBlock
   }
 
   /// Sends an action to mutate the application state.
@@ -60,13 +45,5 @@ public struct StoreProxy<State>: StateStorable, ActionDispatcher {
   /// - Returns: A cancellable object.
   @inlinable public func sendAsCancellable(_ action: Action) -> Cancellable {
     dispatcher.sendAsCancellable(action)
-  }
-
-  /// Passes an action to the next middleware.
-  ///
-  /// Outside of the middleware pipeline this method does nothing.
-  /// - Parameter action: The action to send
-  @inlinable public func next(_ action: Action) {
-    nextBlock?(action)
   }
 }

--- a/Sources/SwiftDux/Store/StoreReducer.swift
+++ b/Sources/SwiftDux/Store/StoreReducer.swift
@@ -12,12 +12,7 @@ public enum StoreAction<State>: Action {
   case reset(state: State)
 }
 
-internal final class StoreReducer<State, RootReducer>: Reducer where RootReducer: Reducer, RootReducer.State == State {
-  private let rootReducer: RootReducer
-
-  init(rootReducer: RootReducer) {
-    self.rootReducer = rootReducer
-  }
+internal final class StoreReducer<State>: Reducer {
 
   @inlinable public func reduce(state: State, action: StoreAction<State>) -> State {
     switch action {
@@ -26,9 +21,5 @@ internal final class StoreReducer<State, RootReducer>: Reducer where RootReducer
     default:
       return state
     }
-  }
-
-  @inlinable public func reduceNext(state: State, action: Action) -> State {
-    rootReducer.reduceAny(state: state, action: action)
   }
 }

--- a/Sources/SwiftDux/UI/Connector.swift
+++ b/Sources/SwiftDux/UI/Connector.swift
@@ -30,6 +30,8 @@ public struct Connector<Content, State, Props>: View where Props: Equatable, Con
     store.map { store in
       Group {
         props.map { content($0) }
+        // SwiftUI sometimes crashes without this line in iOS 14+:
+        EmptyView()
       }.onReceive(store.publish(mapState)) { self.props = $0 }
     }
   }

--- a/Sources/SwiftDuxExtras/Persistence/PersistStateMiddleware.swift
+++ b/Sources/SwiftDuxExtras/Persistence/PersistStateMiddleware.swift
@@ -45,9 +45,8 @@ public final class PersistStateMiddleware<State, SP>: Middleware where SP: State
     self.shouldRestore = shouldRestore
   }
 
-  public func run(store: StoreProxy<State>, action: Action) {
-    defer { store.next(action) }
-    guard case .prepare = action as? StoreAction<State> else { return }
+  public func run(store: StoreProxy<State>, action: Action) -> Action? {
+    guard case .prepare = action as? StoreAction<State> else { return action }
 
     if let state = persistor.restore(), shouldRestore(state) {
       store.send(StoreAction<State>.reset(state: state))
@@ -64,5 +63,7 @@ public final class PersistStateMiddleware<State, SP>: Middleware where SP: State
     } else {
       print("Failed to initiate persistence using default notifiation center.")
     }
+    
+    return action
   }
 }

--- a/Sources/SwiftDuxExtras/Persistence/PersistStateMiddleware.swift
+++ b/Sources/SwiftDuxExtras/Persistence/PersistStateMiddleware.swift
@@ -63,7 +63,7 @@ public final class PersistStateMiddleware<State, SP>: Middleware where SP: State
     } else {
       print("Failed to initiate persistence using default notifiation center.")
     }
-    
+
     return action
   }
 }

--- a/Sources/SwiftDuxExtras/PrintActionMiddleware.swift
+++ b/Sources/SwiftDuxExtras/PrintActionMiddleware.swift
@@ -21,9 +21,10 @@ public final class PrintActionMiddleware<State>: Middleware {
     self.filter = filter
   }
 
-  public func run<State>(store: StoreProxy<State>, action: Action) {
-    defer { store.next(action) }
-    guard filter(action) else { return }
-    printer(String(describing: action))
+  public func run<State>(store: StoreProxy<State>, action: Action) -> Action? {
+    if filter(action) {
+      printer(String(describing: action))
+    }
+    return action
   }
 }

--- a/Tests/SwiftDuxTests/Action/ActionPlanTests.swift
+++ b/Tests/SwiftDuxTests/Action/ActionPlanTests.swift
@@ -13,7 +13,7 @@ final class ActionPlanTests: XCTestCase {
         if let action = action as? TestAction {
           self?.sentActions.append(action)
         }
-        store.next(action)
+        return action
       }
     )
     sentActions = []

--- a/Tests/SwiftDuxTests/Middleware/CompositeMiddlwareTests.swift
+++ b/Tests/SwiftDuxTests/Middleware/CompositeMiddlwareTests.swift
@@ -50,22 +50,20 @@ extension CompositeMiddlewareTests {
   }
   
   final class MiddlewareA: Middleware {
-    func run(store: StoreProxy<TestState>, action: Action) {
+    func run(store: StoreProxy<TestState>, action: Action) -> Action? {
       if case .setText(let text) = action as? TestAction {
-        store.next(TestAction.setText(text + "A"))
-      } else {
-        store.next(action)
+        return TestAction.setText(text + "A")
       }
+      return action
     }
   }
   
   final class MiddlewareB: Middleware {
-    func run(store: StoreProxy<TestState>, action: Action) {
+    func run(store: StoreProxy<TestState>, action: Action) -> Action? {
       if case .setText(let text) = action as? TestAction {
-        store.next(TestAction.setText(text + "B"))
-      } else {
-        store.next(action)
+        return TestAction.setText(text + "B")
       }
+      return action
     }
   }
 }

--- a/Tests/SwiftDuxTests/Store/StoreTests.swift
+++ b/Tests/SwiftDuxTests/Store/StoreTests.swift
@@ -54,47 +54,24 @@ final class StoreTests: XCTestCase {
     XCTAssertEqual(store.state.value, 3)
   }
 
-  func testStoreCleansUpSubscriptions() {
-    let expectation = XCTestExpectation(description: "Expect cancellation")
-    var cancellables = Set<AnyCancellable>()
-    
-    expectation.expectedFulfillmentCount = 6
-    
-    let actionPlan = ActionPlan<TestSendingState> { store, completed in
-      let cancellable = Just(TestSendingAction.setText("test"))
-        .delay(for: .milliseconds(10), scheduler: RunLoop.main)
-        .send(to: store, receivedCompletion: completed)
-      
-      cancellable.store(in: &cancellables)
-      
-      // Make sure there's only one cancellable at a time to validate
-      // the action plans are running synchronously and not leaving
-      // cancellables around.
-      return AnyCancellable {
-        XCTAssertEqual(cancellables.count, 1)
-        cancellables.remove(cancellable)
-        expectation.fulfill()
+  func testFutureAction() {
+    let actionPlan = ActionPlan<TestSendingState> { store in
+      Future<Void, Never> { promise in
+        store.send(TestSendingAction.setText("test"))
+        promise(.success(()))
       }
     }
     
-    let groupedPlans = actionPlan
-      .then(actionPlan)
-      .then(actionPlan)
-      .then(actionPlan)
-      .then(actionPlan)
-      .then(actionPlan)
-    
-    store.send(groupedPlans)
-    
-    wait(for: [expectation], timeout: 1.0)
-    XCTAssertEqual(cancellables.count, 0)
+    let cancellable = actionPlan.run(store: store.proxy()).send(to: store)
+    XCTAssertEqual(store.state.text, "test")
+    cancellable.cancel()
   }
   
   static var allTests = [
     ("testSubscribingToActionPlans", testSubscribingToActionPlans),
     ("testSubscribingToActionPlans", testSubscribingToActionPlans),
     ("testSubscribingToComplexActionPlans", testSubscribingToComplexActionPlans),
-    ("testStoreCleansUpSubscriptions", testStoreCleansUpSubscriptions),
+    ("testStoreCleansUpSubscriptions", testFutureAction),
   ]
 }
 
@@ -103,10 +80,6 @@ extension StoreTests {
   enum TestSendingAction: Action {
     case setText(String)
     case setValue(Int)
-  }
-  
-  enum TestSendingIntruderAction: Action {
-    case setText(String)
   }
   
   struct TestSendingState: Equatable {
@@ -122,14 +95,6 @@ extension StoreTests {
         state.text = text
       case .setValue(let value):
         state.value = value
-      }
-      return state
-    }
-    
-    func reduceNext(state: StoreTests.TestSendingState, action: Action) -> StoreTests.TestSendingState {
-      var state = state
-      if case TestSendingIntruderAction.setText(let text) = action {
-        state.text = text
       }
       return state
     }

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+# Wrap swift-format, so we can return 1 if there's warnings.
+if swift-format -r -m lint Sources 2>&1 | grep 'warning'; then
+echo "Linting failed"
+exit 1
+fi


### PR DESCRIPTION
# Work Performed
- Consolidated chaining methods for actions.
- Removed `next(_:)` method from `StoreProxy`.
- Middleware now returns an optional `Action` instead of calling `next(_:)` off of the `StoreProxy`.
- Added the ReducerMiddleware so that the reducing step can be a part of the middleware pipeline.
- Fixed a circular dependency in the StoreProxy given to middleware.
- Replaced the asynchronous init of ActionPlan with one that returns a publisher to simplify the code.
- Removed the completion handler from ActionSubscriber.
- Fixed a bug introduced in iOS 14 that caused a crash related to the `onReceive` view modifier.