### PR TITLE
Fix: onAppear doesn't call action twice for RunnableAction

### DIFF
--- a/Sources/SwiftDux/UI/ViewModifiers/OnAppearDispatchViewModifier.swift
+++ b/Sources/SwiftDux/UI/ViewModifiers/OnAppearDispatchViewModifier.swift
@@ -54,8 +54,9 @@ extension View {
     Group {
       if let action = action as? RunnableAction {
         modifier(OnAppearDispatchActionPlanViewModifier(action: action, cancelOnDisappear: true))
+      } else {
+        modifier(OnAppearDispatchActionViewModifier(action: action))
       }
-      modifier(OnAppearDispatchActionViewModifier(action: action))
     }
   }
 


### PR DESCRIPTION
Hi, during the SwiftDux update I notice that when `onAppear(dispatch:)` is used with ActionPlan object the view is duplicated. I managed to fix this by adding `else` to the statement.

Thank you for the great library.