### PR TITLE
watchOS setup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
   platforms: [
     .iOS(.v14),
     .macOS(.v11),
+    .watchOS(.v7),
   ],
   products: [
     .library(

--- a/Sources/SwiftDuxExtras/Persistence/PersistStateMiddleware.swift
+++ b/Sources/SwiftDuxExtras/Persistence/PersistStateMiddleware.swift
@@ -2,7 +2,12 @@ import Combine
 import Foundation
 import SwiftDux
 
-#if canImport(UIKit)
+#if canImport(WatchKit)
+
+  import WatchKit
+  fileprivate let notification: NSNotification.Name? = WKExtension.applicationDidEnterBackgroundNotification
+
+#elseif canImport(UIKit)
 
   import UIKit
   fileprivate let notification: NSNotification.Name? = UIApplication.didEnterBackgroundNotification


### PR DESCRIPTION
When I tried to used SwiftDux for the watchOS application, it turns out that Package.swift is missing `.watchOS(.v7),` in the Platforms array and it uses the default watchOS version (something like v2) but this version doesn't have access to Combine.

The second thing that I notice is `#if canImport(UIKit)` from SwiftDuxExtras is true on watchOS but it gives an error about `UIApplication` not found. So I added separated macro `#if canImport(WatchKit)` that should be called on watchOS and it's using `WKExtension.applicationDidEnterBackgroundNotificatio` notification